### PR TITLE
grunt.util.linefeed used for line endings.

### DIFF
--- a/tasks/ts.js
+++ b/tasks/ts.js
@@ -48,11 +48,9 @@ var _ = require('underscore');
 var _str = require('underscore.string');
 var path = require('path');
 var fs = require('fs');
-var os = require('os');
 
 // plain vanilla imports
 var shell = require('shelljs');
-var eol = os.EOL;
 var pathSeperator = path.sep;
 
 var referenceFileLoopState;
@@ -81,6 +79,7 @@ function pluginFn(grunt) {
     function getTsc(binPath) {
         return '"' + binPath + '/' + 'tsc"';
     }
+    var eol = grunt.util.linefeed;
     var exec = shell.exec;
     var cwd = path.resolve(".");
     var tsc = getTsc(resolveTypeScriptBinPath(cwd, 0));

--- a/tasks/ts.ts
+++ b/tasks/ts.ts
@@ -112,10 +112,8 @@ import _ = require('underscore');
 import _str = require('underscore.string');
 import path = require('path');
 import fs = require('fs');
-import os = require('os');
 // plain vanilla imports
 var shell = require('shelljs');
-var eol = os.EOL;
 var pathSeperator = path.sep;
 
 enum referenceFileLoopState { before, unordered, after };
@@ -142,6 +140,7 @@ function pluginFn(grunt: IGrunt) {
     function getTsc(binPath: string): string {
         return '"' + binPath + '/' + 'tsc"';
     }
+    var eol = grunt.util.linefeed;
     var exec = shell.exec;
     var cwd = path.resolve(".");
     var tsc = getTsc(resolveTypeScriptBinPath(cwd, 0));


### PR DESCRIPTION
We had a project which developed on Windows and Unix systems and faced problem with different line endings. I would like to have all line endings in 'LF' format (Unix style), but your plugin uses OS settings without opportunity to override it. Grunt already has utility property grunt.utility.linefeed which calculated this way:

```
// The line feed char for the current system.
util.linefeed = process.platform === 'win32' ? '\r\n' : '\n';
```

so it can be overridden for whole project in Gruntfile.js this way:

```
grunt.util.linefeed = '\n';
```

And by default it will work the same way as yours implementation.
