### PR TITLE
moved reference, amdloader, html2ts, templatecache into their own files

### DIFF
--- a/tasks/modules/amdLoader.js
+++ b/tasks/modules/amdLoader.js
@@ -1,0 +1,282 @@
+/// <reference path="../../defs/tsd.d.ts"/>
+var _ = require('underscore');
+var _str = require('underscore.string');
+var path = require('path');
+var fs = require('fs');
+var os = require('os');
+
+var utils = require('./utils');
+
+var eol = os.EOL;
+var grunt = utils.grunt;
+var pathSeperator = path.sep;
+
+
+(function (ReferenceOrder) {
+    ReferenceOrder[ReferenceOrder["before"] = 0] = "before";
+    ReferenceOrder[ReferenceOrder["unordered"] = 1] = "unordered";
+    ReferenceOrder[ReferenceOrder["after"] = 2] = "after";
+})(exports.ReferenceOrder || (exports.ReferenceOrder = {}));
+var ReferenceOrder = exports.ReferenceOrder;
+
+function getReferencesInOrder(referenceFile, referencePath, generatedFiles) {
+    var toreturn = {
+        all: [],
+        before: [],
+        generated: [],
+        unordered: [],
+        after: []
+    };
+
+    var sortedGeneratedFiles = _.sortBy(generatedFiles);
+
+    function isGeneratedFile(filename) {
+        return _.indexOf(sortedGeneratedFiles, filename, true) !== -1;
+    }
+
+    // When reading
+    var referenceMatch = /\/\/\/ <reference path=\"(.*?)\"/;
+
+    // When writing
+    var referenceIntro = '/// <reference path="';
+
+    // var referenceEnd = '" />';
+    // The section of unordered files
+    var ourSignatureStart = '//grunt-start';
+    var ourSignatureEnd = '//grunt-end';
+
+    var lines = fs.readFileSync(referenceFile).toString().split('\n');
+
+    // Which of the three sections we are in
+    var loopState = 0 /* before */;
+
+    for (var i = 0; i < lines.length; i++) {
+        var line = _str.trim(lines[i]);
+
+        if (_str.include(line, ourSignatureStart)) {
+            // Wait for the end signature:
+            loopState = 1 /* unordered */;
+        }
+        if (_str.include(line, ourSignatureEnd)) {
+            loopState = 2 /* after */;
+        }
+
+        // Fetch the existing reference's filename if any:
+        if (_str.include(line, referenceIntro)) {
+            var match = line.match(referenceMatch);
+            var filename = match[1];
+            switch (loopState) {
+                case 0 /* before */:
+                    toreturn.before.push(filename);
+                    break;
+                case 1 /* unordered */:
+                    if (isGeneratedFile(filename)) {
+                        toreturn.generated.push(filename);
+                    } else {
+                        toreturn.unordered.push(filename);
+                    }
+                    break;
+                case 2 /* after */:
+                    toreturn.after.push(filename);
+                    break;
+            }
+        }
+    }
+
+    // Fix the references to be absolute:
+    toreturn.before = _.map(toreturn.before, function (relativePath) {
+        return path.resolve(referencePath, relativePath);
+    });
+    toreturn.generated = _.map(toreturn.generated, function (relativePath) {
+        return path.resolve(referencePath, relativePath);
+    });
+    toreturn.unordered = _.map(toreturn.unordered, function (relativePath) {
+        return path.resolve(referencePath, relativePath);
+    });
+    toreturn.after = _.map(toreturn.after, function (relativePath) {
+        return path.resolve(referencePath, relativePath);
+    });
+    toreturn.all = Array.prototype.concat.call([], toreturn.before, toreturn.generated, toreturn.unordered, toreturn.after);
+
+    return toreturn;
+}
+exports.getReferencesInOrder = getReferencesInOrder;
+
+// Finds the longest common section of a collection of strings.
+// Simply sorting and comparing first and last http://stackoverflow.com/a/1917041/390330
+function sharedStart(array) {
+    if (array.length === 0) {
+        throw 'Cannot find common root of empty array.';
+    }
+    var A = array.slice(0).sort(), firstWord = A[0], lastWord = A[A.length - 1];
+
+    if (firstWord === lastWord) {
+        return firstWord;
+    } else {
+        var i = -1;
+        do {
+            i += 1;
+            var firstWordChar = firstWord.charAt(i);
+            var lastWordChar = lastWord.charAt(i);
+        } while(firstWordChar === lastWordChar);
+
+        return firstWord.substring(0, i);
+    }
+}
+
+// Explanation inline
+function findCommonPath(paths) {
+    // Now for "C:\u\starter" "C:\u\started" => "C:\u\starte"
+    var largetStartSegement = sharedStart(paths);
+
+    // For "C:\u\starte" => C:\u\
+    var ending = largetStartSegement.lastIndexOf(pathSeperator);
+    return largetStartSegement.substr(0, ending);
+}
+
+// It updates based on the order of reference files
+function updateAmdLoader(referenceFile, files, loaderFile, loaderPath, outDir) {
+    // Read the original file if it exists
+    if (fs.existsSync(referenceFile)) {
+        grunt.log.verbose.writeln('Generating amdloader from reference file ' + referenceFile);
+
+        // Filter.d.ts,
+        if (files.all.length > 0) {
+            grunt.log.verbose.writeln('Files: ' + files.all.map(function (f) {
+                return f.cyan;
+            }).join(', '));
+        } else {
+            grunt.warn('No files in reference file: ' + referenceFile);
+        }
+        if (files.before.length > 0) {
+            files.before = _.filter(files.before, function (file) {
+                return !utils.endsWith(file, '.d.ts');
+            });
+            grunt.log.verbose.writeln('Before: ' + files.before.map(function (f) {
+                return f.cyan;
+            }).join(', '));
+        }
+        if (files.generated.length > 0) {
+            files.generated = _.filter(files.generated, function (file) {
+                return !utils.endsWith(file, '.d.ts');
+            });
+            grunt.log.verbose.writeln('Generated: ' + files.generated.map(function (f) {
+                return f.cyan;
+            }).join(', '));
+        }
+        if (files.unordered.length > 0) {
+            files.unordered = _.filter(files.unordered, function (file) {
+                return !utils.endsWith(file, '.d.ts');
+            });
+            grunt.log.verbose.writeln('Unordered: ' + files.unordered.map(function (f) {
+                return f.cyan;
+            }).join(', '));
+        }
+        if (files.after.length > 0) {
+            files.after = _.filter(files.after, function (file) {
+                return !utils.endsWith(file, '.d.ts');
+            });
+            grunt.log.verbose.writeln('After: ' + files.after.map(function (f) {
+                return f.cyan;
+            }).join(', '));
+        }
+
+        // If target has outDir we need to make adjust the path
+        // c:/somefolder/ts/a , c:/somefolder/ts/inside/b  + c:/somefolder/build/js => c:/somefolder/build/js/a , c:/somefolder/build/js/inside/b
+        // Logic:
+        //     find the common structure in the source files ,and remove it
+        //          Finally: outDir path + remainder section
+        if (outDir) {
+            // Find common path
+            var commonPath = findCommonPath(files.before.concat(files.generated.concat(files.unordered.concat(files.after))));
+            grunt.log.verbose.writeln('Found common path: ' + commonPath);
+
+            // Make sure outDir is absolute:
+            outDir = path.resolve(outDir);
+            grunt.log.verbose.writeln('Using outDir: ' + outDir);
+
+            function makeRelativeToOutDir(files) {
+                files = _.map(files, function (file) {
+                    // Remove common path and replace with absolute outDir
+                    file = file.replace(commonPath, outDir);
+
+                    // remove ts extension '.ts':
+                    file = file.substr(0, file.length - 3);
+
+                    // Make relative to amd loader
+                    file = utils.makeRelativePath(loaderPath, file);
+
+                    // Prepend "./" to prevent "basePath" requirejs setting from interferring:
+                    file = './' + file;
+
+                    return file;
+                });
+                return files;
+            }
+
+            grunt.log.verbose.writeln('Making files relative to outDir...');
+            files.before = makeRelativeToOutDir(files.before);
+            files.generated = makeRelativeToOutDir(files.generated);
+            files.unordered = makeRelativeToOutDir(files.unordered);
+            files.after = makeRelativeToOutDir(files.after);
+
+            var mainTemplate = _.template('define(function (require) { ' + eol + '<%= body %>' + eol + '});');
+
+            // The order in the before and after files is important
+            var singleRequireTemplate = _.template('\t require([<%= filename %>],function (){' + eol + '<%= subitem %>' + eol + '\t });');
+
+            // initial sub item
+            var subitem = '';
+
+            // Write out a binary file:
+            var binaryTemplate = _.template('define(["<%= filenames %>"],function () {});');
+            var binaryFilesNames = files.before.concat(files.generated.concat(files.unordered.concat(files.after)));
+            var binaryContent = binaryTemplate({ filenames: binaryFilesNames.join('","') });
+            var binFileExtension = '.bin.js';
+            var loaderFileWithoutExtension = path.dirname(loaderFile) + pathSeperator + path.basename(loaderFile, '.js');
+            var binFilename = loaderFileWithoutExtension + binFileExtension;
+            fs.writeFileSync(binFilename, binaryContent);
+            grunt.log.verbose.writeln('Binary AMD loader written ' + binFilename.cyan);
+
+            //
+            // Notice that we build inside out in the below sections:
+            //
+            // Generate fileTemplate from inside out
+            // Start with after
+            // Build the subitem for ordered after items
+            files.after = files.after.reverse(); // Important to build inside out
+            _.forEach(files.after, function (file) {
+                subitem = singleRequireTemplate({ filename: '"' + file + '"', subitem: subitem });
+            });
+
+            // Next up add the unordered items:
+            // For these we will use just one require call
+            if (files.unordered.length > 0) {
+                var unorderFileNames = files.unordered.join('",' + eol + '\t\t  "');
+                subitem = singleRequireTemplate({ filename: '"' + unorderFileNames + '"', subitem: subitem });
+            }
+
+            // Next the generated files
+            // For these we will use just one require call
+            var generatedFileNames = files.generated.join('",' + eol + '\t\t  "');
+            subitem = singleRequireTemplate({ filename: '"' + generatedFileNames + '"', subitem: subitem });
+
+            // Build the subitem for ordered before items
+            files.before = files.before.reverse();
+            _.forEach(files.before, function (file) {
+                subitem = singleRequireTemplate({ filename: '"' + file + '"', subitem: subitem });
+            });
+
+            // The last subitem is now the body
+            var output = mainTemplate({ body: subitem });
+
+            // Finally write it out
+            fs.writeFileSync(loaderFile, output);
+            grunt.log.verbose.writeln('AMD loader written ' + loaderFile.cyan);
+        }
+    } else {
+        grunt.log.writeln('Cannot generate amd loader unless a reference file is present'.red);
+    }
+}
+exports.updateAmdLoader = updateAmdLoader;
+//# sourceMappingURL=amdLoader.js.map

--- a/tasks/modules/amdLoader.ts
+++ b/tasks/modules/amdLoader.ts
@@ -1,0 +1,281 @@
+/// <reference path="../../defs/tsd.d.ts"/>
+
+import _ = require('underscore');
+import _str = require('underscore.string');
+import path = require('path');
+import fs = require('fs');
+import os = require('os');
+
+import utils = require('./utils');
+
+var eol = os.EOL;
+var grunt = utils.grunt;
+var pathSeperator = path.sep;
+
+/////////////////////////////////////////////////////////////////////
+// AMD Loader, creates a js file that loads a few files in order
+// and the rest un orderded, based on the reference.ts spec
+////////////////////////////////////////////////////////////////////
+
+export interface IReferences {
+    all: string[];
+    before: string[];
+    generated: string[];
+    unordered: string[];
+    after: string[];
+}
+
+export enum ReferenceOrder {
+    before,
+    unordered,
+    after
+}
+
+export function getReferencesInOrder(referenceFile: string, referencePath: string, generatedFiles: string[]): IReferences {
+    var toreturn: IReferences = {
+        all: [],
+        before: [],
+        generated: [],
+        unordered: [],
+        after: []
+    };
+
+    var sortedGeneratedFiles = _.sortBy(generatedFiles);
+
+    function isGeneratedFile(filename: string): boolean {
+        return _.indexOf(sortedGeneratedFiles, filename, true) !== -1;
+    }
+
+    // When reading
+    var referenceMatch = /\/\/\/ <reference path=\"(.*?)\"/;
+
+    // When writing
+    var referenceIntro = '/// <reference path="';
+    // var referenceEnd = '" />';
+
+    // The section of unordered files
+    var ourSignatureStart = '//grunt-start';
+    var ourSignatureEnd = '//grunt-end';
+
+    var lines = fs.readFileSync(referenceFile).toString().split('\n');
+
+    // Which of the three sections we are in
+    var loopState = ReferenceOrder.before;
+
+    for (var i = 0; i < lines.length; i++) {
+
+        var line = _str.trim(lines[i]);
+
+        if (_str.include(line, ourSignatureStart)) {
+            // Wait for the end signature:
+            loopState = ReferenceOrder.unordered;
+        }
+        if (_str.include(line, ourSignatureEnd)) {
+            loopState = ReferenceOrder.after;
+        }
+
+
+        // Fetch the existing reference's filename if any:
+        if (_str.include(line, referenceIntro)) {
+            var match = line.match(referenceMatch);
+            var filename = match[1];
+            switch (loopState) {
+                case ReferenceOrder.before:
+                    toreturn.before.push(filename);
+                    break;
+                case ReferenceOrder.unordered:
+                    if (isGeneratedFile(filename)) {
+                        toreturn.generated.push(filename);
+                    }
+                    else {
+                        toreturn.unordered.push(filename);
+                    }
+                    break;
+                case ReferenceOrder.after:
+                    toreturn.after.push(filename);
+                    break;
+            }
+        }
+    }
+
+    // Fix the references to be absolute:
+    toreturn.before = _.map(toreturn.before, (relativePath) => path.resolve(referencePath, relativePath));
+    toreturn.generated = _.map(toreturn.generated, (relativePath) => path.resolve(referencePath, relativePath));
+    toreturn.unordered = _.map(toreturn.unordered, (relativePath) => path.resolve(referencePath, relativePath));
+    toreturn.after = _.map(toreturn.after, (relativePath) => path.resolve(referencePath, relativePath));
+    toreturn.all = Array.prototype.concat.call([], toreturn.before, toreturn.generated, toreturn.unordered, toreturn.after);
+
+    return toreturn;
+}
+
+// Finds the longest common section of a collection of strings.
+// Simply sorting and comparing first and last http://stackoverflow.com/a/1917041/390330
+function sharedStart(array: string[]): string {
+    if (array.length === 0) {
+        throw 'Cannot find common root of empty array.';
+    }
+    var A = array.slice(0).sort(),
+        firstWord = A[0],
+        lastWord = A[A.length - 1];
+
+    if (firstWord === lastWord) {
+        return firstWord;
+    }
+    else {
+        var i = -1;
+        do {
+            i += 1;
+            var firstWordChar = firstWord.charAt(i);
+            var lastWordChar = lastWord.charAt(i);
+        } while (firstWordChar === lastWordChar);
+
+        return firstWord.substring(0, i);
+    }
+}
+
+// Explanation inline
+function findCommonPath(paths: string[]) {
+    // Now for "C:\u\starter" "C:\u\started" => "C:\u\starte"
+    var largetStartSegement = sharedStart(paths);
+
+    // For "C:\u\starte" => C:\u\
+    var ending = largetStartSegement.lastIndexOf(pathSeperator);
+    return largetStartSegement.substr(0, ending);
+}
+
+// It updates based on the order of reference files
+export function updateAmdLoader(referenceFile: string, files: IReferences, loaderFile: string, loaderPath: string, outDir: string) {
+
+    // Read the original file if it exists
+    if (fs.existsSync(referenceFile)) {
+        grunt.log.verbose.writeln('Generating amdloader from reference file ' + referenceFile);
+
+        // Filter.d.ts,
+        if (files.all.length > 0) {
+            grunt.log.verbose.writeln('Files: ' + files.all.map((f) => f.cyan).join(', '));
+        }
+        else {
+            grunt.warn('No files in reference file: ' + referenceFile);
+        }
+        if (files.before.length > 0) {
+            files.before = _.filter(files.before, (file) => { return !utils.endsWith(file, '.d.ts'); });
+            grunt.log.verbose.writeln('Before: ' + files.before.map((f) => f.cyan).join(', '));
+        }
+        if (files.generated.length > 0) {
+            files.generated = _.filter(files.generated, (file) => { return !utils.endsWith(file, '.d.ts'); });
+            grunt.log.verbose.writeln('Generated: ' + files.generated.map((f) => f.cyan).join(', '));
+        }
+        if (files.unordered.length > 0) {
+            files.unordered = _.filter(files.unordered, (file) => { return !utils.endsWith(file, '.d.ts'); });
+            grunt.log.verbose.writeln('Unordered: ' + files.unordered.map((f) => f.cyan).join(', '));
+        }
+        if (files.after.length > 0) {
+            files.after = _.filter(files.after, (file) => { return !utils.endsWith(file, '.d.ts'); });
+            grunt.log.verbose.writeln('After: ' + files.after.map((f) => f.cyan).join(', '));
+        }
+
+        // If target has outDir we need to make adjust the path
+        // c:/somefolder/ts/a , c:/somefolder/ts/inside/b  + c:/somefolder/build/js => c:/somefolder/build/js/a , c:/somefolder/build/js/inside/b
+        // Logic:
+        //     find the common structure in the source files ,and remove it
+        //          Finally: outDir path + remainder section
+        if (outDir) {
+            // Find common path
+            var commonPath = findCommonPath(files.before.concat(files.generated.concat(files.unordered.concat(files.after))));
+            grunt.log.verbose.writeln('Found common path: ' + commonPath);
+
+            // Make sure outDir is absolute:
+            outDir = path.resolve(outDir);
+            grunt.log.verbose.writeln('Using outDir: ' + outDir);
+
+            function makeRelativeToOutDir(files: string[]) {
+                files = _.map(files, (file) => {
+                    // Remove common path and replace with absolute outDir
+                    file = file.replace(commonPath, outDir);
+
+                    // remove ts extension '.ts':
+                    file = file.substr(0, file.length - 3);
+
+                    // Make relative to amd loader
+                    file = utils.makeRelativePath(loaderPath, file);
+
+                    // Prepend "./" to prevent "basePath" requirejs setting from interferring:
+                    file = './' + file;
+
+                    return file;
+                });
+                return files;
+            }
+
+            grunt.log.verbose.writeln('Making files relative to outDir...');
+            files.before = makeRelativeToOutDir(files.before);
+            files.generated = makeRelativeToOutDir(files.generated);
+            files.unordered = makeRelativeToOutDir(files.unordered);
+            files.after = makeRelativeToOutDir(files.after);
+
+            var mainTemplate = _.template('define(function (require) { '
+                + eol + '<%= body %>'
+                + eol + '});');
+
+            // The order in the before and after files is important
+            var singleRequireTemplate = _.template('\t require([<%= filename %>],function (){'
+                + eol + '<%= subitem %>'
+                + eol + '\t });');
+
+
+            // initial sub item
+            var subitem = '';
+
+
+            // Write out a binary file:
+            var binaryTemplate = _.template('define(["<%= filenames %>"],function () {});');
+            var binaryFilesNames = files.before.concat(files.generated.concat(files.unordered.concat(files.after)));
+            var binaryContent = binaryTemplate({ filenames: binaryFilesNames.join('","') });
+            var binFileExtension = '.bin.js';
+            var loaderFileWithoutExtension = path.dirname(loaderFile) + pathSeperator + path.basename(loaderFile, '.js');
+            var binFilename = loaderFileWithoutExtension + binFileExtension;
+            fs.writeFileSync(binFilename, binaryContent);
+            grunt.log.verbose.writeln('Binary AMD loader written ' + binFilename.cyan);
+
+            //
+            // Notice that we build inside out in the below sections:
+            //
+
+            // Generate fileTemplate from inside out
+            // Start with after
+            // Build the subitem for ordered after items
+            files.after = files.after.reverse();     // Important to build inside out
+            _.forEach(files.after, (file) => {
+                subitem = singleRequireTemplate({ filename: '"' + file + '"', subitem: subitem });
+            });
+
+            // Next up add the unordered items:
+            // For these we will use just one require call
+            if (files.unordered.length > 0) {
+                var unorderFileNames = files.unordered.join('",' + eol + '\t\t  "');
+                subitem = singleRequireTemplate({ filename: '"' + unorderFileNames + '"', subitem: subitem });
+            }
+
+            // Next the generated files
+            // For these we will use just one require call
+            var generatedFileNames = files.generated.join('",' + eol + '\t\t  "');
+            subitem = singleRequireTemplate({ filename: '"' + generatedFileNames + '"', subitem: subitem });
+
+            // Build the subitem for ordered before items
+            files.before = files.before.reverse();
+            _.forEach(files.before, (file) => {
+                subitem = singleRequireTemplate({ filename: '"' + file + '"', subitem: subitem });
+            });
+
+            // The last subitem is now the body
+            var output = mainTemplate({ body: subitem });
+
+            // Finally write it out
+            fs.writeFileSync(loaderFile, output);
+            grunt.log.verbose.writeln('AMD loader written ' + loaderFile.cyan);
+        }
+    }
+    else {
+        grunt.log.writeln('Cannot generate amd loader unless a reference file is present'.red);
+    }
+}

--- a/tasks/modules/html2ts.js
+++ b/tasks/modules/html2ts.js
@@ -1,0 +1,46 @@
+/// <reference path="../../defs/tsd.d.ts"/>
+var _ = require('underscore');
+var fs = require('fs');
+var path = require('path');
+
+/////////////////////////////////////////////////////////////////////
+// HTML -> TS
+////////////////////////////////////////////////////////////////////
+// html -> js processing functions:
+// Originally from karma-html2js-preprocessor
+// Refactored nicely in html2js grunt task
+// https://github.com/karlgoldstein/grunt-html2js/blob/master/tasks/html2js.js
+// Modified nlReplace to be an empty string
+var escapeContent = function (content, quoteChar) {
+    if (typeof quoteChar === "undefined") { quoteChar = '\''; }
+    var quoteRegexp = new RegExp('\\' + quoteChar, 'g');
+    var nlReplace = '';
+    return content.replace(quoteRegexp, '\\' + quoteChar).replace(/\r?\n/g, nlReplace);
+};
+
+// Remove bom when reading utf8 files
+function stripBOM(str) {
+    return 0xFEFF === str.charCodeAt(0) ? str.substring(1) : str;
+}
+
+var htmlTemplate = _.template('module <%= modulename %> { export var <%= varname %> =  \'<%= content %>\' } ');
+
+// Compile an HTML file to a TS file
+// Return the filename. This filename will be required by reference.ts
+function compileHTML(filename) {
+    var htmlContent = escapeContent(fs.readFileSync(filename).toString());
+    htmlContent = stripBOM(htmlContent);
+
+    // TODO: place a minification pipeline here if you want.
+    var ext = path.extname(filename);
+    var extFreename = path.basename(filename, ext);
+    var fileContent = htmlTemplate({ modulename: extFreename, varname: ext.replace('.', ''), content: htmlContent });
+
+    // Write the content to a file
+    var outputfile = filename + '.ts';
+
+    fs.writeFileSync(outputfile, fileContent);
+    return outputfile;
+}
+exports.compileHTML = compileHTML;
+//# sourceMappingURL=html2ts.js.map

--- a/tasks/modules/html2ts.ts
+++ b/tasks/modules/html2ts.ts
@@ -1,0 +1,47 @@
+/// <reference path="../../defs/tsd.d.ts"/>
+
+import _ = require('underscore');
+import fs = require('fs');
+import path = require('path');
+
+/////////////////////////////////////////////////////////////////////
+// HTML -> TS
+////////////////////////////////////////////////////////////////////
+
+// html -> js processing functions:
+// Originally from karma-html2js-preprocessor
+// Refactored nicely in html2js grunt task
+// https://github.com/karlgoldstein/grunt-html2js/blob/master/tasks/html2js.js
+// Modified nlReplace to be an empty string
+var escapeContent = function (content: string, quoteChar= '\''): string {
+    var quoteRegexp = new RegExp('\\' + quoteChar, 'g');
+    var nlReplace = '';
+    return content.replace(quoteRegexp, '\\' + quoteChar).replace(/\r?\n/g, nlReplace);
+};
+
+// Remove bom when reading utf8 files
+function stripBOM(str) {
+    return 0xFEFF === str.charCodeAt(0)
+        ? str.substring(1)
+        : str;
+}
+
+var htmlTemplate = _.template('module <%= modulename %> { export var <%= varname %> =  \'<%= content %>\' } ');
+
+// Compile an HTML file to a TS file
+// Return the filename. This filename will be required by reference.ts
+export function compileHTML(filename: string): string {
+    var htmlContent = escapeContent(fs.readFileSync(filename).toString());
+    htmlContent = stripBOM(htmlContent);
+    // TODO: place a minification pipeline here if you want.
+
+    var ext = path.extname(filename);
+    var extFreename = path.basename(filename, ext);
+    var fileContent = htmlTemplate({ modulename: extFreename, varname: ext.replace('.', ''), content: htmlContent });
+
+    // Write the content to a file
+    var outputfile = filename + '.ts';
+
+    fs.writeFileSync(outputfile, fileContent);
+    return outputfile;
+}

--- a/tasks/modules/reference.js
+++ b/tasks/modules/reference.js
@@ -1,0 +1,111 @@
+/// <reference path="../../defs/tsd.d.ts"/>
+var _ = require('underscore');
+var _str = require('underscore.string');
+var fs = require('fs');
+var os = require('os');
+
+var utils = require('./utils');
+
+var eol = os.EOL;
+
+/////////////////////////////////////////////////////////////////////
+// Reference file logic
+////////////////////////////////////////////////////////////////////
+// Updates the reference file
+function updateReferenceFile(files, generatedFiles, referenceFile, referencePath) {
+    var referenceIntro = '/// <reference path="';
+    var referenceEnd = '" />';
+    var referenceMatch = /\/\/\/ <reference path=\"(.*?)\"/;
+    var ourSignatureStart = '//grunt-start';
+    var ourSignatureEnd = '//grunt-end';
+
+    var lines = [];
+    var origFileLines = [];
+    var origFileReferences = [];
+
+    // Location of our generated references
+    // By default at start of file
+    var signatureSectionPosition = 0;
+    var i;
+
+    // Read the original file if it exists
+    if (fs.existsSync(referenceFile)) {
+        lines = fs.readFileSync(referenceFile).toString().split('\n');
+
+        var inSignatureSection = false;
+
+        // By default our signature goes at end of file
+        signatureSectionPosition = lines.length;
+
+        for (i = 0; i < lines.length; i++) {
+            var line = _str.trim(lines[i]);
+
+            // Skip logic for our generated section
+            if (_str.include(line, ourSignatureStart)) {
+                // Wait for the end signature:
+                signatureSectionPosition = i;
+                inSignatureSection = true;
+                continue;
+            }
+            if (_str.include(line, ourSignatureEnd)) {
+                inSignatureSection = false;
+                continue;
+            }
+            if (inSignatureSection) {
+                continue;
+            }
+
+            // store the line
+            origFileLines.push(line);
+
+            // Fetch the existing reference's filename if any:
+            if (_str.include(line, referenceIntro)) {
+                var match = line.match(referenceMatch);
+                var filename = match[1];
+                origFileReferences.push(filename);
+            }
+        }
+    }
+
+    // Put in the generated files
+    generatedFiles = _.map(generatedFiles, function (file) {
+        return referenceIntro + utils.makeRelativePath(referencePath, file) + referenceEnd;
+    });
+    var contents = utils.insertArrayAt([ourSignatureStart], 1, generatedFiles);
+
+    // Put in the new / observed missing files:
+    files.forEach(function (filename) {
+        // The file we are about to add
+        var filepath = utils.makeRelativePath(referencePath, filename);
+
+        // If there are orig references
+        if (origFileReferences.length) {
+            if (_.contains(origFileReferences, filepath)) {
+                return;
+            }
+        }
+
+        // Finally add the filepath
+        contents.push(referenceIntro + filepath + referenceEnd);
+    });
+    contents.push(ourSignatureEnd);
+
+    // Modify the orig contents to put in our contents
+    var updatedFileLines = utils.insertArrayAt(origFileLines, signatureSectionPosition, contents);
+    fs.writeFileSync(referenceFile, updatedFileLines.join(eol));
+
+    // Return whether the file was changed
+    if (lines.length === updatedFileLines.length) {
+        var updated = false;
+        for (i = 0; i < lines.length; i++) {
+            if (lines[i] !== updatedFileLines[i]) {
+                updated = true;
+            }
+        }
+        return updated;
+    } else {
+        return true;
+    }
+}
+exports.updateReferenceFile = updateReferenceFile;
+//# sourceMappingURL=reference.js.map

--- a/tasks/modules/reference.ts
+++ b/tasks/modules/reference.ts
@@ -1,0 +1,112 @@
+/// <reference path="../../defs/tsd.d.ts"/>
+
+import _ = require('underscore');
+import _str = require('underscore.string');
+import fs = require('fs');
+import os = require('os');
+
+import utils = require('./utils');
+
+var eol = os.EOL;
+
+
+/////////////////////////////////////////////////////////////////////
+// Reference file logic
+////////////////////////////////////////////////////////////////////    
+
+// Updates the reference file
+export function updateReferenceFile(files: string[], generatedFiles: string[], referenceFile: string, referencePath: string): boolean {
+    var referenceIntro = '/// <reference path="';
+    var referenceEnd = '" />';
+    var referenceMatch = /\/\/\/ <reference path=\"(.*?)\"/;
+    var ourSignatureStart = '//grunt-start';
+    var ourSignatureEnd = '//grunt-end';
+
+    var lines = []; // All lines of the file
+    var origFileLines = []; // The lines we do not modify and send out as is. Lines will we reach grunt-ts generated
+    var origFileReferences = []; // The list of files already there that we do not need to manage
+
+    // Location of our generated references
+    // By default at start of file
+    var signatureSectionPosition = 0;
+    var i;
+
+    // Read the original file if it exists
+    if (fs.existsSync(referenceFile)) {
+        lines = fs.readFileSync(referenceFile).toString().split('\n');
+
+        var inSignatureSection = false;
+
+        // By default our signature goes at end of file
+        signatureSectionPosition = lines.length;
+
+        for (i = 0; i < lines.length; i++) {
+
+            var line = _str.trim(lines[i]);
+
+            // Skip logic for our generated section
+            if (_str.include(line, ourSignatureStart)) {
+                // Wait for the end signature:
+                signatureSectionPosition = i;
+                inSignatureSection = true;
+                continue;
+            }
+            if (_str.include(line, ourSignatureEnd)) {
+                inSignatureSection = false;
+                continue;
+            }
+            if (inSignatureSection) {
+                continue;
+            }
+
+            // store the line
+            origFileLines.push(line);
+
+            // Fetch the existing reference's filename if any:
+            if (_str.include(line, referenceIntro)) {
+                var match = line.match(referenceMatch);
+                var filename = match[1];
+                origFileReferences.push(filename);
+            }
+        }
+    }
+
+    // Put in the generated files
+    generatedFiles = _.map(generatedFiles, (file) => referenceIntro + utils.makeRelativePath(referencePath, file) + referenceEnd);
+    var contents = utils.insertArrayAt([ourSignatureStart], 1, generatedFiles);
+
+    // Put in the new / observed missing files:
+    files.forEach((filename: string) => {
+        // The file we are about to add
+        var filepath = utils.makeRelativePath(referencePath, filename);
+
+        // If there are orig references
+        if (origFileReferences.length) {
+            if (_.contains(origFileReferences, filepath)) {
+                return;
+            }
+        }
+
+        // Finally add the filepath
+        contents.push(referenceIntro + filepath + referenceEnd);
+    });
+    contents.push(ourSignatureEnd);
+
+    // Modify the orig contents to put in our contents
+    var updatedFileLines = utils.insertArrayAt(origFileLines, signatureSectionPosition, contents);
+    fs.writeFileSync(referenceFile, updatedFileLines.join(eol));
+
+    // Return whether the file was changed
+    if (lines.length === updatedFileLines.length) {
+        var updated = false;
+        for (i = 0; i < lines.length; i++) {
+            if (lines[i] !== updatedFileLines[i]) {
+                updated = true;
+            }
+        }
+        return updated;
+    }
+    else {
+        return true;
+    }
+}

--- a/tasks/modules/templateCache.js
+++ b/tasks/modules/templateCache.js
@@ -1,0 +1,53 @@
+/// <reference path="../../defs/tsd.d.ts"/>
+var _ = require('underscore');
+var fs = require('fs');
+var path = require('path');
+var os = require('os');
+
+var utils = require('./utils');
+
+var eol = os.EOL;
+
+/////////////////////////////////////////////////////////////////////
+// AngularJS templateCache
+////////////////////////////////////////////////////////////////////
+// templateCache processing function
+function generateTemplateCache(src, dest, basePath) {
+    if (!src.length) {
+        return;
+    }
+
+    // Resolve the relative path from basePath to each src file
+    var relativePaths = _.map(src, function (anHtmlFile) {
+        return 'text!' + utils.makeRelativePath(basePath, anHtmlFile);
+    });
+    var fileNames = _.map(src, function (anHtmlFile) {
+        return path.basename(anHtmlFile);
+    });
+    var fileVarialbeName = function (anHtmlFile) {
+        return anHtmlFile.split('.').join('_').split('-').join('_');
+    };
+    var fileVariableNames = _.map(fileNames, fileVarialbeName);
+
+    var templateCacheTemplate = _.template('// You must have requirejs + text plugin loaded for this to work.' + eol + 'define([<%=relativePathSection%>],function(<%=fileNameVariableSection%>){' + eol + 'angular.module("ng").run(["$templateCache",function($templateCache) {' + eol + '<%=templateCachePut%>' + eol + '}]);' + eol + '});');
+
+    var relativePathSection = '"' + relativePaths.join('",' + eol + '"') + '"';
+    var fileNameVariableSection = fileVariableNames.join(',' + eol);
+
+    var templateCachePutTemplate = _.template('$templateCache.put("<%= fileName %>", <%=fileVariableName%>);');
+    var templateCachePut = _.map(fileNames, function (fileName) {
+        return templateCachePutTemplate({
+            fileName: fileName,
+            fileVariableName: fileVarialbeName(fileName)
+        });
+    }).join(eol);
+
+    var fileContent = templateCacheTemplate({
+        relativePathSection: relativePathSection,
+        fileNameVariableSection: fileNameVariableSection,
+        templateCachePut: templateCachePut
+    });
+    fs.writeFileSync(dest, fileContent);
+}
+exports.generateTemplateCache = generateTemplateCache;
+//# sourceMappingURL=templateCache.js.map

--- a/tasks/modules/templateCache.ts
+++ b/tasks/modules/templateCache.ts
@@ -1,0 +1,53 @@
+/// <reference path="../../defs/tsd.d.ts"/>
+
+import _ = require('underscore');
+import fs = require('fs');
+import path = require('path');
+import os = require('os');
+
+import utils = require('./utils');
+
+var eol = os.EOL;
+
+
+/////////////////////////////////////////////////////////////////////
+// AngularJS templateCache
+////////////////////////////////////////////////////////////////////
+
+// templateCache processing function
+
+export function generateTemplateCache(src: string[], dest: string, basePath: string) {
+    if (!src.length) {
+        return;
+    }
+
+    // Resolve the relative path from basePath to each src file
+    var relativePaths: string[] = _.map(src, (anHtmlFile) => 'text!' + utils.makeRelativePath(basePath, anHtmlFile));
+    var fileNames: string[] = _.map(src, (anHtmlFile) => path.basename(anHtmlFile));
+    var fileVarialbeName = (anHtmlFile) => anHtmlFile.split('.').join('_').split('-').join('_');
+    var fileVariableNames: string[] = _.map(fileNames, fileVarialbeName);
+
+
+    var templateCacheTemplate = _.template('// You must have requirejs + text plugin loaded for this to work.'
+        + eol + 'define([<%=relativePathSection%>],function(<%=fileNameVariableSection%>){'
+        + eol + 'angular.module("ng").run(["$templateCache",function($templateCache) {'
+        + eol + '<%=templateCachePut%>'
+        + eol + '}]);'
+        + eol + '});');
+
+    var relativePathSection = '"' + relativePaths.join('",' + eol + '"') + '"';
+    var fileNameVariableSection = fileVariableNames.join(',' + eol);
+
+    var templateCachePutTemplate = _.template('$templateCache.put("<%= fileName %>", <%=fileVariableName%>);');
+    var templateCachePut = _.map(fileNames, (fileName) => templateCachePutTemplate({
+        fileName: fileName,
+        fileVariableName: fileVarialbeName(fileName)
+    })).join(eol);
+
+    var fileContent = templateCacheTemplate({
+        relativePathSection: relativePathSection,
+        fileNameVariableSection: fileNameVariableSection,
+        templateCachePut: templateCachePut
+    });
+    fs.writeFileSync(dest, fileContent);
+}

--- a/tasks/modules/utils.js
+++ b/tasks/modules/utils.js
@@ -11,6 +11,27 @@ function makeRelativePath(folderpath, filename) {
 }
 exports.makeRelativePath = makeRelativePath;
 
+/**
+* Returns the result of an array inserted into another, starting at the given index.
+*/
+function insertArrayAt(array, index, arrayToInsert) {
+    var updated = array.slice(0);
+    var spliceAt = [index, 0];
+    Array.prototype.splice.apply(updated, spliceAt.concat(arrayToInsert));
+    return updated;
+}
+exports.insertArrayAt = insertArrayAt;
+
+/**
+* Compares the end of the string with the given suffix for literal equality.
+*
+* @returns {boolean} whether the string ends with the suffix literally.
+*/
+function endsWith(str, suffix) {
+    return str.indexOf(suffix, str.length - suffix.length) !== -1;
+}
+exports.endsWith = endsWith;
+
 // From https://github.com/centi/node-dirutils/blob/master/index.js
 // Slightly modified. See BAS
 /**

--- a/tasks/modules/utils.ts
+++ b/tasks/modules/utils.ts
@@ -11,6 +11,27 @@ export function makeRelativePath(folderpath: string, filename: string) {
     return path.relative(folderpath, filename).split('\\').join('/');
 }
 
+
+/**
+ * Returns the result of an array inserted into another, starting at the given index.
+ */
+export function insertArrayAt<T>(array: T[], index: number, arrayToInsert: T[]): T[] {
+    var updated = array.slice(0);
+    var spliceAt: any[] = [index, 0];
+    Array.prototype.splice.apply(updated, spliceAt.concat(arrayToInsert));
+    return updated;
+}
+
+/**
+ * Compares the end of the string with the given suffix for literal equality.
+ *
+ * @returns {boolean} whether the string ends with the suffix literally.
+ */
+export function endsWith(str: string, suffix: string): boolean {
+    return str.indexOf(suffix, str.length - suffix.length) !== -1;
+}
+
+
 // From https://github.com/centi/node-dirutils/blob/master/index.js
 // Slightly modified. See BAS
 

--- a/tasks/ts.js
+++ b/tasks/ts.js
@@ -5,44 +5,20 @@
 */
 // Typescript imports
 var _ = require('underscore');
-var _str = require('underscore.string');
 var path = require('path');
 var fs = require('fs');
 
 // Modules of grunt-ts
 var utils = require('./modules/utils');
 var indexModule = require('./modules/index');
+var referenceModule = require('./modules/reference');
+var amdLoaderModule = require('./modules/amdLoader');
+var html2tsModule = require('./modules/html2ts');
+var templateCacheModule = require('./modules/templateCache');
 
 // plain vanilla imports
-var pathSeperator = path.sep;
 var Promise = require('es6-promise').Promise;
 
-var ReferenceOrder;
-(function (ReferenceOrder) {
-    ReferenceOrder[ReferenceOrder["before"] = 0] = "before";
-    ReferenceOrder[ReferenceOrder["unordered"] = 1] = "unordered";
-    ReferenceOrder[ReferenceOrder["after"] = 2] = "after";
-})(ReferenceOrder || (ReferenceOrder = {}));
-
-
-/**
-* Returns the result of an array inserted into another, starting at the given index.
-*/
-function insertArrayAt(array, index, arrayToInsert) {
-    var updated = array.slice(0);
-    var spliceAt = [index, 0];
-    Array.prototype.splice.apply(updated, spliceAt.concat(arrayToInsert));
-    return updated;
-}
-
-/**
-* Compares the end of the string with the given suffix for literal equality.
-*
-* @returns {boolean} whether the string ends with the suffix literally.
-*/
-function endsWith(str, suffix) {
-    return str.indexOf(suffix, str.length - suffix.length) !== -1;
-}
 
 /**
 * Time a function and print the result.
@@ -163,8 +139,6 @@ function pluginFn(grunt) {
         return path.join(binPath, 'tsc');
     }
 
-    var eol = grunt.util.linefeed;
-
     // Blindly runs the tsc task using provided options
     function compileAllFiles(files, target, task) {
         var args = files.slice(0);
@@ -237,451 +211,6 @@ function pluginFn(grunt) {
             fs.unlinkSync(tempfilename);
             throw err;
         });
-    }
-
-    /////////////////////////////////////////////////////////////////////
-    // Reference file logic
-    ////////////////////////////////////////////////////////////////////
-    // Updates the reference file
-    function updateReferenceFile(files, generatedFiles, referenceFile, referencePath) {
-        var referenceIntro = '/// <reference path="';
-        var referenceEnd = '" />';
-        var referenceMatch = /\/\/\/ <reference path=\"(.*?)\"/;
-        var ourSignatureStart = '//grunt-start';
-        var ourSignatureEnd = '//grunt-end';
-
-        var lines = [];
-        var origFileLines = [];
-        var origFileReferences = [];
-
-        // Location of our generated references
-        // By default at start of file
-        var signatureSectionPosition = 0;
-        var i;
-
-        // Read the original file if it exists
-        if (fs.existsSync(referenceFile)) {
-            lines = fs.readFileSync(referenceFile).toString().split('\n');
-
-            var inSignatureSection = false;
-
-            // By default our signature goes at end of file
-            signatureSectionPosition = lines.length;
-
-            for (i = 0; i < lines.length; i++) {
-                var line = _str.trim(lines[i]);
-
-                // Skip logic for our generated section
-                if (_str.include(line, ourSignatureStart)) {
-                    // Wait for the end signature:
-                    signatureSectionPosition = i;
-                    inSignatureSection = true;
-                    continue;
-                }
-                if (_str.include(line, ourSignatureEnd)) {
-                    inSignatureSection = false;
-                    continue;
-                }
-                if (inSignatureSection) {
-                    continue;
-                }
-
-                // store the line
-                origFileLines.push(line);
-
-                // Fetch the existing reference's filename if any:
-                if (_str.include(line, referenceIntro)) {
-                    var match = line.match(referenceMatch);
-                    var filename = match[1];
-                    origFileReferences.push(filename);
-                }
-            }
-        }
-
-        // Put in the generated files
-        generatedFiles = _.map(generatedFiles, function (file) {
-            return referenceIntro + utils.makeRelativePath(referencePath, file) + referenceEnd;
-        });
-        var contents = insertArrayAt([ourSignatureStart], 1, generatedFiles);
-
-        // Put in the new / observed missing files:
-        files.forEach(function (filename) {
-            // The file we are about to add
-            var filepath = utils.makeRelativePath(referencePath, filename);
-
-            // If there are orig references
-            if (origFileReferences.length) {
-                if (_.contains(origFileReferences, filepath)) {
-                    return;
-                }
-            }
-
-            // Finally add the filepath
-            contents.push(referenceIntro + filepath + referenceEnd);
-        });
-        contents.push(ourSignatureEnd);
-
-        // Modify the orig contents to put in our contents
-        var updatedFileLines = insertArrayAt(origFileLines, signatureSectionPosition, contents);
-        fs.writeFileSync(referenceFile, updatedFileLines.join(eol));
-
-        // Return whether the file was changed
-        if (lines.length === updatedFileLines.length) {
-            var updated = false;
-            for (i = 0; i < lines.length; i++) {
-                if (lines[i] !== updatedFileLines[i]) {
-                    updated = true;
-                }
-            }
-            return updated;
-        } else {
-            return true;
-        }
-    }
-
-    /////////////////////////////////////////////////////////////////////
-    // AMD Loader, creates a js file that loads a few files in order
-    // and the rest un orderded, based on the reference.ts spec
-    ////////////////////////////////////////////////////////////////////
-    function getReferencesInOrder(referenceFile, referencePath, generatedFiles) {
-        var toreturn = {
-            all: [],
-            before: [],
-            generated: [],
-            unordered: [],
-            after: []
-        };
-
-        var sortedGeneratedFiles = _.sortBy(generatedFiles);
-
-        function isGeneratedFile(filename) {
-            return _.indexOf(sortedGeneratedFiles, filename, true) !== -1;
-        }
-
-        // When reading
-        var referenceMatch = /\/\/\/ <reference path=\"(.*?)\"/;
-
-        // When writing
-        var referenceIntro = '/// <reference path="';
-
-        // var referenceEnd = '" />';
-        // The section of unordered files
-        var ourSignatureStart = '//grunt-start';
-        var ourSignatureEnd = '//grunt-end';
-
-        var lines = fs.readFileSync(referenceFile).toString().split('\n');
-
-        // Which of the three sections we are in
-        var loopState = 0 /* before */;
-
-        for (var i = 0; i < lines.length; i++) {
-            var line = _str.trim(lines[i]);
-
-            if (_str.include(line, ourSignatureStart)) {
-                // Wait for the end signature:
-                loopState = 1 /* unordered */;
-            }
-            if (_str.include(line, ourSignatureEnd)) {
-                loopState = 2 /* after */;
-            }
-
-            // Fetch the existing reference's filename if any:
-            if (_str.include(line, referenceIntro)) {
-                var match = line.match(referenceMatch);
-                var filename = match[1];
-                switch (loopState) {
-                    case 0 /* before */:
-                        toreturn.before.push(filename);
-                        break;
-                    case 1 /* unordered */:
-                        if (isGeneratedFile(filename)) {
-                            toreturn.generated.push(filename);
-                        } else {
-                            toreturn.unordered.push(filename);
-                        }
-                        break;
-                    case 2 /* after */:
-                        toreturn.after.push(filename);
-                        break;
-                }
-            }
-        }
-
-        // Fix the references to be absolute:
-        toreturn.before = _.map(toreturn.before, function (relativePath) {
-            return path.resolve(referencePath, relativePath);
-        });
-        toreturn.generated = _.map(toreturn.generated, function (relativePath) {
-            return path.resolve(referencePath, relativePath);
-        });
-        toreturn.unordered = _.map(toreturn.unordered, function (relativePath) {
-            return path.resolve(referencePath, relativePath);
-        });
-        toreturn.after = _.map(toreturn.after, function (relativePath) {
-            return path.resolve(referencePath, relativePath);
-        });
-        toreturn.all = Array.prototype.concat.call([], toreturn.before, toreturn.generated, toreturn.unordered, toreturn.after);
-
-        return toreturn;
-    }
-
-    // Finds the longest common section of a collection of strings.
-    // Simply sorting and comparing first and last http://stackoverflow.com/a/1917041/390330
-    function sharedStart(array) {
-        if (array.length === 0) {
-            throw 'Cannot find common root of empty array.';
-        }
-        var A = array.slice(0).sort(), firstWord = A[0], lastWord = A[A.length - 1];
-
-        if (firstWord === lastWord) {
-            return firstWord;
-        } else {
-            var i = -1;
-            do {
-                i += 1;
-                var firstWordChar = firstWord.charAt(i);
-                var lastWordChar = lastWord.charAt(i);
-            } while(firstWordChar === lastWordChar);
-
-            return firstWord.substring(0, i);
-        }
-    }
-
-    // Explanation inline
-    function findCommonPath(paths) {
-        // Now for "C:\u\starter" "C:\u\started" => "C:\u\starte"
-        var largetStartSegement = sharedStart(paths);
-
-        // For "C:\u\starte" => C:\u\
-        var ending = largetStartSegement.lastIndexOf(pathSeperator);
-        return largetStartSegement.substr(0, ending);
-    }
-
-    // It updates based on the order of reference files
-    function updateAmdLoader(referenceFile, files, loaderFile, loaderPath, outDir) {
-        // Read the original file if it exists
-        if (fs.existsSync(referenceFile)) {
-            grunt.log.verbose.writeln('Generating amdloader from reference file ' + referenceFile);
-
-            // Filter.d.ts,
-            if (files.all.length > 0) {
-                grunt.log.verbose.writeln('Files: ' + files.all.map(function (f) {
-                    return f.cyan;
-                }).join(', '));
-            } else {
-                grunt.warn('No files in reference file: ' + referenceFile);
-            }
-            if (files.before.length > 0) {
-                files.before = _.filter(files.before, function (file) {
-                    return !endsWith(file, '.d.ts');
-                });
-                grunt.log.verbose.writeln('Before: ' + files.before.map(function (f) {
-                    return f.cyan;
-                }).join(', '));
-            }
-            if (files.generated.length > 0) {
-                files.generated = _.filter(files.generated, function (file) {
-                    return !endsWith(file, '.d.ts');
-                });
-                grunt.log.verbose.writeln('Generated: ' + files.generated.map(function (f) {
-                    return f.cyan;
-                }).join(', '));
-            }
-            if (files.unordered.length > 0) {
-                files.unordered = _.filter(files.unordered, function (file) {
-                    return !endsWith(file, '.d.ts');
-                });
-                grunt.log.verbose.writeln('Unordered: ' + files.unordered.map(function (f) {
-                    return f.cyan;
-                }).join(', '));
-            }
-            if (files.after.length > 0) {
-                files.after = _.filter(files.after, function (file) {
-                    return !endsWith(file, '.d.ts');
-                });
-                grunt.log.verbose.writeln('After: ' + files.after.map(function (f) {
-                    return f.cyan;
-                }).join(', '));
-            }
-
-            // If target has outDir we need to make adjust the path
-            // c:/somefolder/ts/a , c:/somefolder/ts/inside/b  + c:/somefolder/build/js => c:/somefolder/build/js/a , c:/somefolder/build/js/inside/b
-            // Logic:
-            //     find the common structure in the source files ,and remove it
-            //          Finally: outDir path + remainder section
-            if (outDir) {
-                // Find common path
-                var commonPath = findCommonPath(files.before.concat(files.generated.concat(files.unordered.concat(files.after))));
-                grunt.log.verbose.writeln('Found common path: ' + commonPath);
-
-                // Make sure outDir is absolute:
-                outDir = path.resolve(outDir);
-                grunt.log.verbose.writeln('Using outDir: ' + outDir);
-
-                function makeRelativeToOutDir(files) {
-                    files = _.map(files, function (file) {
-                        // Remove common path and replace with absolute outDir
-                        file = file.replace(commonPath, outDir);
-
-                        // remove ts extension '.ts':
-                        file = file.substr(0, file.length - 3);
-
-                        // Make relative to amd loader
-                        file = utils.makeRelativePath(loaderPath, file);
-
-                        // Prepend "./" to prevent "basePath" requirejs setting from interferring:
-                        file = './' + file;
-
-                        return file;
-                    });
-                    return files;
-                }
-
-                grunt.log.verbose.writeln('Making files relative to outDir...');
-                files.before = makeRelativeToOutDir(files.before);
-                files.generated = makeRelativeToOutDir(files.generated);
-                files.unordered = makeRelativeToOutDir(files.unordered);
-                files.after = makeRelativeToOutDir(files.after);
-
-                var mainTemplate = _.template('define(function (require) { ' + eol + '<%= body %>' + eol + '});');
-
-                // The order in the before and after files is important
-                var singleRequireTemplate = _.template('\t require([<%= filename %>],function (){' + eol + '<%= subitem %>' + eol + '\t });');
-
-                // initial sub item
-                var subitem = '';
-
-                // Write out a binary file:
-                var binaryTemplate = _.template('define(["<%= filenames %>"],function () {});');
-                var binaryFilesNames = files.before.concat(files.generated.concat(files.unordered.concat(files.after)));
-                var binaryContent = binaryTemplate({ filenames: binaryFilesNames.join('","') });
-                var binFileExtension = '.bin.js';
-                var loaderFileWithoutExtension = path.dirname(loaderFile) + pathSeperator + path.basename(loaderFile, '.js');
-                var binFilename = loaderFileWithoutExtension + binFileExtension;
-                fs.writeFileSync(binFilename, binaryContent);
-                grunt.log.verbose.writeln('Binary AMD loader written ' + binFilename.cyan);
-
-                //
-                // Notice that we build inside out in the below sections:
-                //
-                // Generate fileTemplate from inside out
-                // Start with after
-                // Build the subitem for ordered after items
-                files.after = files.after.reverse(); // Important to build inside out
-                _.forEach(files.after, function (file) {
-                    subitem = singleRequireTemplate({ filename: '"' + file + '"', subitem: subitem });
-                });
-
-                // Next up add the unordered items:
-                // For these we will use just one require call
-                if (files.unordered.length > 0) {
-                    var unorderFileNames = files.unordered.join('",' + eol + '\t\t  "');
-                    subitem = singleRequireTemplate({ filename: '"' + unorderFileNames + '"', subitem: subitem });
-                }
-
-                // Next the generated files
-                // For these we will use just one require call
-                var generatedFileNames = files.generated.join('",' + eol + '\t\t  "');
-                subitem = singleRequireTemplate({ filename: '"' + generatedFileNames + '"', subitem: subitem });
-
-                // Build the subitem for ordered before items
-                files.before = files.before.reverse();
-                _.forEach(files.before, function (file) {
-                    subitem = singleRequireTemplate({ filename: '"' + file + '"', subitem: subitem });
-                });
-
-                // The last subitem is now the body
-                var output = mainTemplate({ body: subitem });
-
-                // Finally write it out
-                fs.writeFileSync(loaderFile, output);
-                grunt.log.verbose.writeln('AMD loader written ' + loaderFile.cyan);
-            }
-        } else {
-            grunt.log.writeln('Cannot generate amd loader unless a reference file is present'.red);
-        }
-    }
-
-    /////////////////////////////////////////////////////////////////////
-    // HTML -> TS
-    ////////////////////////////////////////////////////////////////////
-    // html -> js processing functions:
-    // Originally from karma-html2js-preprocessor
-    // Refactored nicely in html2js grunt task
-    // https://github.com/karlgoldstein/grunt-html2js/blob/master/tasks/html2js.js
-    // Modified nlReplace to be an empty string
-    var escapeContent = function (content, quoteChar) {
-        if (typeof quoteChar === "undefined") { quoteChar = '\''; }
-        var quoteRegexp = new RegExp('\\' + quoteChar, 'g');
-        var nlReplace = '';
-        return content.replace(quoteRegexp, '\\' + quoteChar).replace(/\r?\n/g, nlReplace);
-    };
-
-    // Remove bom when reading utf8 files
-    function stripBOM(str) {
-        return 0xFEFF === str.charCodeAt(0) ? str.substring(1) : str;
-    }
-
-    var htmlTemplate = _.template('module <%= modulename %> { export var <%= varname %> =  \'<%= content %>\' } ');
-
-    // Compile an HTML file to a TS file
-    // Return the filename. This filename will be required by reference.ts
-    function compileHTML(filename) {
-        var htmlContent = escapeContent(fs.readFileSync(filename).toString());
-        htmlContent = stripBOM(htmlContent);
-
-        // TODO: place a minification pipeline here if you want.
-        var ext = path.extname(filename);
-        var extFreename = path.basename(filename, ext);
-        var fileContent = htmlTemplate({ modulename: extFreename, varname: ext.replace('.', ''), content: htmlContent });
-
-        // Write the content to a file
-        var outputfile = filename + '.ts';
-
-        fs.writeFileSync(outputfile, fileContent);
-        return outputfile;
-    }
-
-    /////////////////////////////////////////////////////////////////////
-    // AngularJS templateCache
-    ////////////////////////////////////////////////////////////////////
-    // templateCache processing function
-    function generateTemplateCache(src, dest, basePath) {
-        if (!src.length) {
-            return;
-        }
-
-        // Resolve the relative path from basePath to each src file
-        var relativePaths = _.map(src, function (anHtmlFile) {
-            return 'text!' + utils.makeRelativePath(basePath, anHtmlFile);
-        });
-        var fileNames = _.map(src, function (anHtmlFile) {
-            return path.basename(anHtmlFile);
-        });
-        var fileVarialbeName = function (anHtmlFile) {
-            return anHtmlFile.split('.').join('_').split('-').join('_');
-        };
-        var fileVariableNames = _.map(fileNames, fileVarialbeName);
-
-        var templateCacheTemplate = _.template('// You must have requirejs + text plugin loaded for this to work.' + eol + 'define([<%=relativePathSection%>],function(<%=fileNameVariableSection%>){' + eol + 'angular.module("ng").run(["$templateCache",function($templateCache) {' + eol + '<%=templateCachePut%>' + eol + '}]);' + eol + '});');
-
-        var relativePathSection = '"' + relativePaths.join('",' + eol + '"') + '"';
-        var fileNameVariableSection = fileVariableNames.join(',' + eol);
-
-        var templateCachePutTemplate = _.template('$templateCache.put("<%= fileName %>", <%=fileVariableName%>);');
-        var templateCachePut = _.map(fileNames, function (fileName) {
-            return templateCachePutTemplate({
-                fileName: fileName,
-                fileVariableName: fileVarialbeName(fileName)
-            });
-        }).join(eol);
-
-        var fileContent = templateCacheTemplate({
-            relativePathSection: relativePathSection,
-            fileNameVariableSection: fileNameVariableSection,
-            templateCachePut: templateCachePut
-        });
-        fs.writeFileSync(dest, fileContent);
     }
 
     /////////////////////////////////////////////////////////////////////
@@ -832,7 +361,7 @@ function pluginFn(grunt) {
                 if (currenttask.data.html) {
                     var htmlFiles = grunt.file.expand(currenttask.data.html);
                     generatedHtmlFiles = _.map(htmlFiles, function (filename) {
-                        return compileHTML(filename);
+                        return html2tsModule.compileHTML(filename);
                     });
                 }
 
@@ -845,7 +374,7 @@ function pluginFn(grunt) {
                         var templateCacheSrc = grunt.file.expand(currenttask.data.templateCache.src);
                         var templateCacheDest = path.resolve(target.templateCache.dest);
                         var templateCacheBasePath = path.resolve(target.templateCache.baseUrl);
-                        generateTemplateCache(templateCacheSrc, templateCacheDest, templateCacheBasePath);
+                        templateCacheModule.generateTemplateCache(templateCacheSrc, templateCacheDest, templateCacheBasePath);
                     }
                 }
 
@@ -882,7 +411,7 @@ function pluginFn(grunt) {
                     // Create a reference file if specified
                     if (!!referencePath) {
                         var result = timeIt(function () {
-                            return updateReferenceFile(files, generatedHtmlFiles, referenceFile, referencePath);
+                            return referenceModule.updateReferenceFile(files, generatedHtmlFiles, referenceFile, referencePath);
                         });
                         if (result.it === true) {
                             grunt.log.writeln(('Updated reference file (' + result.time + 'ms).').green);
@@ -894,8 +423,8 @@ function pluginFn(grunt) {
                         return runCompilation(files, target, options).then(function (success) {
                             // Create the loader if specified & compiliation succeeded
                             if (success && !!amdloaderPath) {
-                                var referenceOrder = getReferencesInOrder(referenceFile, referencePath, generatedHtmlFiles);
-                                updateAmdLoader(referenceFile, referenceOrder, amdloaderFile, amdloaderPath, target.outDir);
+                                var referenceOrder = amdLoaderModule.getReferencesInOrder(referenceFile, referencePath, generatedHtmlFiles);
+                                amdLoaderModule.updateAmdLoader(referenceFile, referenceOrder, amdloaderFile, amdloaderPath, target.outDir);
                             }
                             return success;
                         });
@@ -917,7 +446,7 @@ function pluginFn(grunt) {
                 // local event to handle file event
                 function handleFileEvent(filepath, displaystr) {
                     // Only ts and html :
-                    if (!endsWith(filepath.toLowerCase(), '.ts') && !endsWith(filepath.toLowerCase(), '.html')) {
+                    if (!utils.endsWith(filepath.toLowerCase(), '.ts') && !utils.endsWith(filepath.toLowerCase(), '.html')) {
                         return;
                     }
 


### PR DESCRIPTION
This helps with maintainability. `ts.ts` is hereby a compilation (perhaps this should be moved out as well) + setting parsing only. 
