### PR TITLE
added `fast` boolean target option.

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -182,9 +182,10 @@ module.exports = function (grunt) {
             },
             fail: {
                 fail: true,                  // a designed to fail target
+                fast: true,
                 src: ['test/fail/**/*.ts'],
+                outDir: 'test/fail/js',
                 // watch: 'test',
-                reference: 'test/fail/reference.ts',
                 options: {                  // overide the main options for this target 
                     sourcemap: false,
                 }

--- a/build.bat
+++ b/build.bat
@@ -1,4 +1,5 @@
 tsc "./tasks/ts.ts" --sourcemap --module commonjs
-tsc "./test/test.ts" --sourcemap --module commonjs
+REM tsc "./test/test.ts" --sourcemap --module commonjs
 REM grunt ts:index
-grunt nodeunit
+REM grunt nodeunit
+REM grunt ts:fail

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
     "author": "basarat",
     "name": "grunt-ts",
     "description": "Compile and manage your TypeScript project",
-    "version": "1.7.3",
+    "version": "1.7.4",
     "homepage": "https://github.com/grunt-ts/grunt-ts",
     "repository": {
         "type": "git",

--- a/test/fail/reference.ts
+++ b/test/fail/reference.ts
@@ -1,4 +1,0 @@
-//grunt-start
-/// <reference path="fail.ts" />
-/// <reference path="work.ts" />
-//grunt-end


### PR DESCRIPTION
Behaviour : When watching, only compile the changed file + disable codegen (only if `--out` isn't specified).

Note: With this (thanks to @Bartvds awesome parallel compile) if you change `n` files we will spawn `n` tsc instances and compile all of them in parallel. 
