### PR TITLE
Update chokidar dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     },
     "dependencies": {
         "typescript": "0.9.5",
-        "chokidar": "0.8.1",
+        "chokidar": "0.8.2",
         "underscore": "1.5.1",
         "underscore.string": "2.3.3",
         "es6-promise": "~0.1.1",


### PR DESCRIPTION
You should update the chokidar dependency as it solved a bug installing it on non-Mac devices.
Maybe you should consider using a range like `"chokidar": "~0.8.2"` for all dependencies?
