### PR TITLE
Additional error summary

### DIFF
--- a/tasks/ts.js
+++ b/tasks/ts.js
@@ -230,29 +230,47 @@ function pluginFn(grunt) {
                     //   Level 1 errors = syntax errors - prevent JS emit.
                     //   Level 2 errors = semantic errors - *not* prevents JS emit.
                     //   Level 5 errors = compiler flag misuse - prevents JS emit.
-                    var level1ErrorCount = 0, level5ErrorCount = 0, nonEmitPreventingErrorCount = 0;
+                    var level1ErrorCount = 0, level5ErrorCount = 0, nonEmitPreventingWarningCount = 0;
                     var hasPreventEmitErrors = _.foldl(result.output.split('\n'), function (memo, errorMsg) {
-                        var isLikelyEmitError = true;
+                        var isPreventEmitError = false;
                         if (errorMsg.search(/error TS1\d+:/g) >= 0) {
                             level1ErrorCount += 1;
+                            isPreventEmitError = true;
                         } else if (errorMsg.search(/error TS5\d+:/) >= 0) {
                             level5ErrorCount += 1;
-                        } else {
-                            nonEmitPreventingErrorCount += 1;
-                            isLikelyEmitError = false;
+                            isPreventEmitError = true;
+                        } else if (errorMsg.search(/error TS\d+:/) >= 0) {
+                            nonEmitPreventingWarningCount += 1;
                         }
-                        return memo || isLikelyEmitError;
+                        return memo || isPreventEmitError;
                     }, false) || false;
 
                     // Because we can't think of a better way to determine it,
                     //   assume that emitted JS in spite of error codes implies type-only errors.
                     var isOnlyTypeErrors = !hasPreventEmitErrors;
 
-                    grunt.log.writeln(level5ErrorCount.toString() + ' compiler flag error' + (level5ErrorCount === 1 ? '' : 's') + ', ' + level1ErrorCount.toString() + ' syntax error' + (level1ErrorCount === 1 ? '' : 's') + ', ' + nonEmitPreventingErrorCount.toString() + ' non-emit-preventing type error' + (nonEmitPreventingErrorCount === 1 ? '' : 's') + '.');
+                    // Log error summary
+                    if (level1ErrorCount + level5ErrorCount + nonEmitPreventingWarningCount > 0) {
+                        if (level1ErrorCount + level5ErrorCount > 0) {
+                            grunt.log.write(('>> ').red);
+                        } else {
+                            grunt.log.write(('>> ').green);
+                        }
 
-                    // Explain our interpretation of the tsc errors before we mark build results.
-                    if (isError) {
+                        if (level5ErrorCount > 0) {
+                            grunt.log.write(level5ErrorCount.toString() + ' compiler flag error' + (level5ErrorCount === 1 ? '' : 's') + '  ');
+                        }
+                        if (level1ErrorCount > 0) {
+                            grunt.log.write(level1ErrorCount.toString() + ' syntax error' + (level1ErrorCount === 1 ? '' : 's') + '  ');
+                        }
+                        if (nonEmitPreventingWarningCount > 0) {
+                            grunt.log.write(nonEmitPreventingWarningCount.toString() + ' non-emit-preventing type warning' + (nonEmitPreventingWarningCount === 1 ? '' : 's') + '  ');
+                        }
+
+                        grunt.log.writeln('');
+
                         if (isOnlyTypeErrors) {
+                            grunt.log.write(('>> ').green);
                             grunt.log.writeln('Type errors only.');
                         }
                     }

--- a/tasks/ts.ts
+++ b/tasks/ts.ts
@@ -250,36 +250,53 @@ function pluginFn(grunt: IGrunt) {
                     //   Level 1 errors = syntax errors - prevent JS emit.
                     //   Level 2 errors = semantic errors - *not* prevents JS emit.
                     //   Level 5 errors = compiler flag misuse - prevents JS emit.
-                    var level1ErrorCount = 0, level5ErrorCount = 0, nonEmitPreventingErrorCount = 0;
+                    var level1ErrorCount = 0, level5ErrorCount = 0, nonEmitPreventingWarningCount = 0;
                     var hasPreventEmitErrors = _.foldl(result.output.split('\n'), function(memo, errorMsg: string) {
-                        var isLikelyEmitError = true;
+                        var isPreventEmitError = false;
                         if (errorMsg.search(/error TS1\d+:/g) >= 0) {
                           level1ErrorCount += 1;
+                          isPreventEmitError = true;
                         } else if (errorMsg.search(/error TS5\d+:/) >= 0) {
                           level5ErrorCount += 1;
-                        } else {
-                          nonEmitPreventingErrorCount += 1;
-                          isLikelyEmitError = false;
+                          isPreventEmitError = true;
+                        } else if (errorMsg.search(/error TS\d+:/) >= 0) {
+                          nonEmitPreventingWarningCount += 1;
                         }
-                        return memo || isLikelyEmitError;
+                        return memo || isPreventEmitError;
                     }, false) || false;
 
                     // Because we can't think of a better way to determine it,
                     //   assume that emitted JS in spite of error codes implies type-only errors.
                     var isOnlyTypeErrors = !hasPreventEmitErrors;
 
-                    grunt.log.writeln(level5ErrorCount.toString() +
-                      ' compiler flag error' + (level5ErrorCount === 1 ? '' : 's') + ', ' +
-                      level1ErrorCount.toString() +
-                      ' syntax error' + (level1ErrorCount === 1 ? '' : 's') + ', ' +
-                      nonEmitPreventingErrorCount.toString() +
-                      ' non-emit-preventing type error' + (nonEmitPreventingErrorCount === 1 ? '' : 's')  + '.');
+                    // Log error summary
+                    if (level1ErrorCount + level5ErrorCount + nonEmitPreventingWarningCount > 0) {
+                      if (level1ErrorCount + level5ErrorCount > 0) {
+                        grunt.log.write(('>> ').red);
+                      } else {
+                        grunt.log.write(('>> ').green);
+                      }
 
-                    // Explain our interpretation of the tsc errors before we mark build results.
-                    if (isError) {
-                        if (isOnlyTypeErrors) {
-                            grunt.log.writeln('Type errors only.');
-                        }
+                      if (level5ErrorCount > 0) {
+                        grunt.log.write(level5ErrorCount.toString() + ' compiler flag error' +
+                          (level5ErrorCount === 1 ? '' : 's') + '  ');
+                      }
+                      if (level1ErrorCount > 0) {
+                        grunt.log.write(level1ErrorCount.toString() + ' syntax error' +
+                          (level1ErrorCount === 1 ? '' : 's') + '  ');
+                      }
+                      if (nonEmitPreventingWarningCount > 0) {
+                        grunt.log.write(nonEmitPreventingWarningCount.toString() +
+                          ' non-emit-preventing type warning' +
+                          (nonEmitPreventingWarningCount === 1 ? '' : 's') + '  ');
+                      }
+
+                      grunt.log.writeln('');
+
+                      if (isOnlyTypeErrors) {
+                        grunt.log.write(('>> ').green);
+                        grunt.log.writeln('Type errors only.');
+                      }
                     }
 
                     // !!! To do: To really be confident that the build was actually successful,


### PR DESCRIPTION
I added some summary info to the log.  If there are no detected errors, nothing is logged.  However, in the case of compiler, syntax, or type errors, some additional stuff is shown.  I made it so the double chevron shows as red or green based on the presence of only non-emit-preventing type warnings.

![grunt-ts error reporting](https://cloud.githubusercontent.com/assets/3755379/3560461/9bb73498-096e-11e4-8547-5213e5753075.png)

I think that this could be further improved by summarizing type warnings per file.  If it seems a bit silly that there might ever be 172 type errors across multiple files, this is actually very plausible if you've either just implemented TypeScript from plain JS or else if you've just turned on no implicit any.

Please let me know what you think.

Note: the ts:fail task is failing when I build this.  I'm assuming that's ok?
