### PR TITLE
Update transformers.ts to allow space between '///' and 'ts:'

### DIFF
--- a/tasks/modules/transformers.ts
+++ b/tasks/modules/transformers.ts
@@ -86,7 +86,7 @@ function getTargetFolders(targetFiles: string[]) {
 class BaseTransformer {
 
     static tsSignature = '///ts:';
-    static tsSignatureMatch = '///ts:{0}=(.*)';
+    static tsSignatureMatch = '///\\s?ts:{0}=(.*)';
 
     intro: string;
     match: RegExp;


### PR DESCRIPTION
I'm occasionally seeing the first `///ts:import` being changed to `/// ts:import` after a code cleanup, which results in the import being deleted from the code and the compile failing.

AFAIK all other `///`-style comments support white space between the start of the comment and the content.
