### PR TITLE
Allow alternate variable names in import/export transforms

### DIFF
--- a/tasks/modules/transformers.js
+++ b/tasks/modules/transformers.js
@@ -205,7 +205,7 @@ function transformFiles(changedFiles, targetFiles, target, task) {
     ];
 
     _.forEach(changedFiles, function (fileToProcess) {
-        var contents = fs.readFileSync(fileToProcess).toString();
+        var contents = fs.readFileSync(fileToProcess, 'utf8').toString();
 
         // If no signature don't bother with this file
         if (!BaseTransformer.containsTransformSignature(contents)) {

--- a/tasks/modules/transformers.ts
+++ b/tasks/modules/transformers.ts
@@ -236,7 +236,7 @@ export function transformFiles(
     ];
 
     _.forEach(changedFiles, (fileToProcess) => {
-        var contents = fs.readFileSync(fileToProcess).toString();
+        var contents = fs.readFileSync(fileToProcess, 'utf8').toString();
 
         // If no signature don't bother with this file
         if (!BaseTransformer.containsTransformSignature(contents)) {


### PR DESCRIPTION
Resolves #143 and updated version and Readme accordingly.

I also added an "unknown" transform which will output an error message given any `///ts:???` where `???` is not a valid transform. There was a comment in CHANGELOG about adding such a feature and I figured I was already in there so I might as well do it.
