### PR TITLE
Allow watch on multiple directories rather than a single directory

### DIFF
--- a/tasks/ts.js
+++ b/tasks/ts.js
@@ -405,8 +405,8 @@ function pluginFn(grunt) {
                     filterFilesAndCompile();
                 }
 
-                // get path
-                var watchpath = path.resolve(watch);
+                // get path(s)
+                var watchpath = grunt.file.expand(watch);
 
                 // create a file watcher for path
                 var chokidar = require('chokidar');

--- a/tasks/ts.ts
+++ b/tasks/ts.ts
@@ -436,8 +436,8 @@ function pluginFn(grunt: IGrunt) {
                     filterFilesAndCompile();
                 }
 
-                // get path
-                var watchpath = path.resolve(watch);
+                // get path(s)
+                var watchpath = grunt.file.expand(watch);
 
                 // create a file watcher for path
                 var chokidar = require('chokidar');


### PR DESCRIPTION
Hi,
Made a one line change to allow multiple folders to be watched rather than a single one.

i.e. in gruntfile.js
                watch: ['app','lib','typings'],                  // If specified, watches this directory for changes, and re-runs 

seems to work quite nicely for my purposes, but I'm new to grunt, node and git so it might have unexpected consequences!
