### PR TITLE
Add options.strictMode to fail build on warnings

### DIFF
--- a/tasks/modules/interfaces.d.ts
+++ b/tasks/modules/interfaces.d.ts
@@ -1,17 +1,17 @@
 
 interface ITargetOptions {
-    src: string[]; // input files  // Note : this is a getter and returns a new "live globbed" array 
+    src: string[]; // input files  // Note : this is a getter and returns a new "live globbed" array
     dest?: string;
     files: {
         src: string[];
         dest: string;
     }[];
     reference: string; // path to a reference.ts e.g. './approot/'
-    out: string; // if sepecified e.g. 'single.js' all output js files are merged into single.js using tsc --out command     
+    out: string; // if sepecified e.g. 'single.js' all output js files are merged into single.js using tsc --out command
     outDir: string; // if sepecified e.g. '/build/js' all output js files are put in this location
-    baseDir: string; // If specified. outDir files are made relative to this. 
+    baseDir: string; // If specified. outDir files are made relative to this.
     html: string[];  // if specified this is used to generate typescript files with a single variable which contains the content of the html
-    watch: string; // if specified watches all files in this directory for changes. 
+    watch: string; // if specified watches all files in this directory for changes.
     amdloader: string;  // if specified creates a js file to load all the generated typescript files in order using requirejs + order
     templateCache: {
         src: string[]; // if search through all the html files at this location
@@ -58,4 +58,6 @@ interface ITaskOptions {
 
     htmlModuleTemplate: string;
     htmlVarTemplate: string;
+
+    strictMode: boolean;
 }

--- a/tasks/ts.js
+++ b/tasks/ts.js
@@ -98,7 +98,8 @@ function pluginFn(grunt) {
             compiler: '',
             htmlModuleTemplate: '<%= filename %>',
             htmlVarTemplate: '<%= ext %>',
-            failOnTypeErrors: true
+            failOnTypeErrors: true,
+            strictMode: false
         });
 
         // get unprocessed templates from configuration
@@ -303,7 +304,7 @@ function pluginFn(grunt) {
 
                     // Log error summary
                     if (level1ErrorCount + level5ErrorCount + nonEmitPreventingWarningCount > 0) {
-                        if (level1ErrorCount + level5ErrorCount > 0) {
+                        if (level1ErrorCount + level5ErrorCount > 0 || options.strictMode) {
                             grunt.log.write(('>> ').red);
                         } else {
                             grunt.log.write(('>> ').green);
@@ -321,9 +322,14 @@ function pluginFn(grunt) {
 
                         grunt.log.writeln('');
 
-                        if (isOnlyTypeErrors) {
+                        if (isOnlyTypeErrors && !options.strictMode) {
                             grunt.log.write(('>> ').green);
                             grunt.log.writeln('Type errors only.');
+                        }
+
+                        if (options.strictMode && nonEmitPreventingWarningCount > 0) {
+                            isError = true;
+                            isOnlyTypeErrors = false;
                         }
                     }
 

--- a/tasks/ts.ts
+++ b/tasks/ts.ts
@@ -113,6 +113,7 @@ function pluginFn(grunt: IGrunt) {
             htmlModuleTemplate: '<%= filename %>',
             htmlVarTemplate: '<%= ext %>',
             failOnTypeErrors: true,
+            strictMode: false,
         });
 
         // get unprocessed templates from configuration
@@ -328,7 +329,7 @@ function pluginFn(grunt: IGrunt) {
 
                         // Log error summary
                         if (level1ErrorCount + level5ErrorCount + nonEmitPreventingWarningCount > 0) {
-                          if (level1ErrorCount + level5ErrorCount > 0) {
+                          if (level1ErrorCount + level5ErrorCount > 0 || options.strictMode) {
                             grunt.log.write(('>> ').red);
                           } else {
                             grunt.log.write(('>> ').green);
@@ -350,9 +351,14 @@ function pluginFn(grunt: IGrunt) {
 
                           grunt.log.writeln('');
 
-                          if (isOnlyTypeErrors) {
+                          if (isOnlyTypeErrors && !options.strictMode) {
                             grunt.log.write(('>> ').green);
                             grunt.log.writeln('Type errors only.');
+                          }
+
+                          if (options.strictMode && nonEmitPreventingWarningCount > 0) {
+                            isError = true;
+                            isOnlyTypeErrors = false;
                           }
                         }
 
@@ -377,7 +383,7 @@ function pluginFn(grunt: IGrunt) {
                     });
             }
 
-            // Find out which files to compile, codegen etc. 
+            // Find out which files to compile, codegen etc.
             // Then calls the appropriate functions + compile function on those files
             function filterFilesAndCompile(): Promise<boolean> {
 
@@ -446,7 +452,7 @@ function pluginFn(grunt: IGrunt) {
                 }
 
                 ///// AMD loader
-                // Create the amdLoader if specified 
+                // Create the amdLoader if specified
                 if (!!amdloaderPath) {
                     var referenceOrder: amdLoaderModule.IReferences
                         = amdLoaderModule.getReferencesInOrder(referenceFile, referencePath, generatedFiles);


### PR DESCRIPTION
When you have swag warnings are unacceptable. By adding the option `strictMode` you can let the build fail on all warnings as well.
