### PR TITLE
Document failOnTypeErrors in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -333,7 +333,9 @@ grunt.initConfig({
 				// true | false (default)
                 declaration: false,
 				// true (default) | false
-                removeComments: true
+                removeComments: true,
+				// true (default) | false
+                failOnTypeErrors: true,
             },
         },
 		// Another target


### PR DESCRIPTION
Documents an option added in 47374dc58d408041dda9df40916d9390ba5a8965.
