### PR TITLE
PR: Add option to specify the output directory for generated .html.ts file

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -10,7 +10,8 @@ module.exports = function (grunt) {
                 'test/**/*.html.ts',
                 '.tscache/**/*',
                 '!test/test.js',
-                '!test/expected/**/*'
+                '!test/expected/**/*',
+                'test/htmlOutDir/generated/test'
             ],
             testPost: [
                 'src/a.js',
@@ -271,6 +272,18 @@ module.exports = function (grunt) {
                 reference: 'test/htmlOutDir/reference.ts',
                 htmlOutDir: 'test/htmlOutDir/generated',
                 out: 'test/htmlOutDir/out.js'
+            },
+            htmlWithFlatHtmlOutDirTest: {
+                test: true,
+                src: ['test/htmlOutDirFlat/reference.ts','test/htmlOutDirFlat/src/bar.ts',
+                    'test/htmlOutDirFlat/src/foo.ts',
+                    //NOTE Not strictly necessarily based on the implementation
+                    'test/htmlOutDirFlat/generated/**/*.ts'],
+                html: ['test/htmlOutDirFlat/**/*.tpl.html'],
+                reference: 'test/htmlOutDirFlat/reference.ts',
+                htmlOutDir: 'test/htmlOutDirFlat/generated',
+                htmlOutDirFlatten: true,
+                out: 'test/htmlOutDirFlat/out.js'
             },
             definitelyTypedTest: {
                 test: true,

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -261,6 +261,17 @@ module.exports = function (grunt) {
                 reference: 'test/html/reference.ts',
                 out: 'test/html/out.js',
             },
+            htmlWithHtmlOutDirTest: {
+                test: true,
+                src: ['test/htmlOutDir/reference.ts','test/htmlOutDir/src/bar.ts',
+                    'test/htmlOutDir/src/foo.ts',
+                    //NOTE Not strictly necessarily based on the implementation
+                    'test/htmlOutDir/generated/**/*.ts'],
+                html: ['test/htmlOutDir/**/*.tpl.html'],
+                reference: 'test/htmlOutDir/reference.ts',
+                htmlOutDir: 'test/htmlOutDir/generated',
+                out: 'test/htmlOutDir/out.js'
+            },
             definitelyTypedTest: {
                 test: true,
                 src: ['test/definitelytypedtest/**/*.ts'],

--- a/README.md
+++ b/README.md
@@ -231,10 +231,6 @@ It is possible to specify this string to the template on a view: http://emberjs.
 
 Specifically: http://stackoverflow.com/a/9867375/390330
 
-#### Html 2 TypeScript: Separate generation directory
-
-It is possible to specify an alternative directory to which the `.html.ts` files will be generated using the option `htmlOutDir`.
-
 ### Live file watching and building
 
 Grunt-ts can watch a directory and recompile TypeScript files when any TypeScript file changes, gets added, gets removed. Use the `watch` *target* option specifying a target directory that will be watched.
@@ -318,8 +314,6 @@ grunt.initConfig({
 			src: ["test/work/**/*.ts"],
 			// The source html files, https://github.com/grunt-ts/grunt-ts#html-2-typescript-support
             html: ["test/work/**/*.tpl.html"],
-			// The directory generated .html.ts files are stored.
-            htmlOutDir: ["test/work/generated"],
 			// If specified, generate this file that to can use for reference management
 			reference: "./test/reference.ts",  
 			// If specified, generate an out.js file which is the merged js file

--- a/README.md
+++ b/README.md
@@ -231,6 +231,10 @@ It is possible to specify this string to the template on a view: http://emberjs.
 
 Specifically: http://stackoverflow.com/a/9867375/390330
 
+#### Html 2 TypeScript: Separate generation directory
+
+It is possible to specify an alternative directory to which the `.html.ts` files will be generated using the option `htmlOutDir`.
+
 ### Live file watching and building
 
 Grunt-ts can watch a directory and recompile TypeScript files when any TypeScript file changes, gets added, gets removed. Use the `watch` *target* option specifying a target directory that will be watched.
@@ -314,6 +318,8 @@ grunt.initConfig({
 			src: ["test/work/**/*.ts"],
 			// The source html files, https://github.com/grunt-ts/grunt-ts#html-2-typescript-support
             html: ["test/work/**/*.tpl.html"],
+			// The directory generated .html.ts files are stored.
+            htmlOutDir: ["test/work/generated"],
 			// If specified, generate this file that to can use for reference management
 			reference: "./test/reference.ts",  
 			// If specified, generate an out.js file which is the merged js file

--- a/tasks-internal/modules/interfaces.d.ts
+++ b/tasks-internal/modules/interfaces.d.ts
@@ -7,6 +7,7 @@ interface ITargetOptions {
     baseDir: string; // If specified. outDir files are made relative to this. 
     html: string[];  // if specified this is used to generate typescript files with a single variable which contains the content of the html
     htmlOutDir: string; // if specified with html, the generated typescript file will be produce in the directory
+    htmlOutDirFlatten: boolean; // if specified with htmlOutDir, the files will be flat in the htmlOutDir
     watch: string; // if specified watches all files in this directory for changes. 
     amdloader: string;  // if specified creates a js file to load all the generated typescript files in order using requirejs + order
     templateCache: {
@@ -54,4 +55,5 @@ interface ITaskOptions {
     htmlModuleTemplate: string;
     htmlVarTemplate: string;
     htmlOutDir: string;
+    htmlOutDirFlatten: boolean;
 }

--- a/tasks-internal/modules/interfaces.d.ts
+++ b/tasks-internal/modules/interfaces.d.ts
@@ -6,6 +6,7 @@ interface ITargetOptions {
     outDir: string; // if sepecified e.g. '/build/js' all output js files are put in this location
     baseDir: string; // If specified. outDir files are made relative to this. 
     html: string[];  // if specified this is used to generate typescript files with a single variable which contains the content of the html
+    htmlOutDir: string; // if specified with html, the generated typescript file will be produce in the directory
     watch: string; // if specified watches all files in this directory for changes. 
     amdloader: string;  // if specified creates a js file to load all the generated typescript files in order using requirejs + order
     templateCache: {
@@ -52,4 +53,5 @@ interface ITaskOptions {
 
     htmlModuleTemplate: string;
     htmlVarTemplate: string;
+    htmlOutDir: string;
 }

--- a/tasks/modules/html2ts.js
+++ b/tasks/modules/html2ts.js
@@ -41,10 +41,34 @@ function compileHTML(filename, options) {
     var fileContent = htmlTemplate({ modulename: moduleName, varname: varName, content: htmlContent });
 
     // Write the content to a file
-    var outputfile = filename + '.ts';
+    var outputfile = getOutputFile(filename, options.htmlOutDir);
 
     fs.writeFileSync(outputfile, fileContent);
     return outputfile;
 }
 exports.compileHTML = compileHTML;
+
+function getOutputFile(filename, htmlOutDir) {
+    var outputfile = filename;
+
+    // NOTE If an htmlOutDir was specified
+    if (htmlOutDir !== null) {
+        var dir = getPath(htmlOutDir);
+
+        if (fs.existsSync(dir)) {
+            var unqualifiedFilename = path.basename(filename);
+            outputfile = path.join(dir, unqualifiedFilename);
+        }
+    }
+    return outputfile + '.ts';
+}
+
+function getPath(dir) {
+    // NOTE If we don't have a valid absolute path
+    if (!fs.existsSync(dir)) {
+        // NOTE Try relative from the current working directory
+        dir = path.join(process.cwd(), dir);
+    }
+    return dir;
+}
 //# sourceMappingURL=html2ts.js.map

--- a/tasks/modules/html2ts.ts
+++ b/tasks/modules/html2ts.ts
@@ -30,7 +30,8 @@ var htmlTemplate = _.template('module <%= modulename %> { export var <%= varname
 
 export interface IHtml2TSOptions {
     moduleFunction: Function;
-    varFunction: Function
+    varFunction: Function;
+    htmlOutDir: string;
 }
 
 // Compile an HTML file to a TS file
@@ -49,8 +50,32 @@ export function compileHTML(filename: string, options: IHtml2TSOptions): string 
     var fileContent = htmlTemplate({ modulename: moduleName, varname: varName, content: htmlContent });
 
     // Write the content to a file
-    var outputfile = filename + '.ts';
+    var outputfile = getOutputFile(filename, options.htmlOutDir);
 
     fs.writeFileSync(outputfile, fileContent);
     return outputfile;
+}
+
+function getOutputFile(filename: string, htmlOutDir: string): string {
+    var outputfile = filename;
+
+    // NOTE If an htmlOutDir was specified
+    if (htmlOutDir !== null) {
+        var dir = getPath(htmlOutDir);
+
+        if (fs.existsSync(dir)) {
+            var unqualifiedFilename = path.basename(filename);
+            outputfile = path.join(dir, unqualifiedFilename);
+        }
+    }
+    return outputfile + '.ts';
+}
+
+function getPath(dir: string): string {
+    // NOTE If we don't have a valid absolute path
+    if (!fs.existsSync(dir)) {
+        // NOTE Try relative from the current working directory
+        dir = path.join(process.cwd(), dir);
+    }
+    return dir;
 }

--- a/tasks/modules/interfaces.d.ts
+++ b/tasks/modules/interfaces.d.ts
@@ -12,6 +12,7 @@ interface ITargetOptions {
     baseDir: string; // If specified. outDir files are made relative to this. 
     html: string[];  // if specified this is used to generate typescript files with a single variable which contains the content of the html
     htmlOutDir: string; // if specified with html, the generated typescript file will be produce in the directory
+    htmlOutDirFlatten: boolean; // if specified with htmlOutDir, the files will be flat in the htmlOutDir
     watch: string; // if specified watches all files in this directory for changes. 
     amdloader: string;  // if specified creates a js file to load all the generated typescript files in order using requirejs + order
     templateCache: {
@@ -60,4 +61,5 @@ interface ITaskOptions {
     htmlModuleTemplate: string;
     htmlVarTemplate: string;
     htmlOutDir: string;
+    htmlOutDirFlatten: boolean;
 }

--- a/tasks/modules/interfaces.d.ts
+++ b/tasks/modules/interfaces.d.ts
@@ -11,6 +11,7 @@ interface ITargetOptions {
     outDir: string; // if sepecified e.g. '/build/js' all output js files are put in this location
     baseDir: string; // If specified. outDir files are made relative to this. 
     html: string[];  // if specified this is used to generate typescript files with a single variable which contains the content of the html
+    htmlOutDir: string; // if specified with html, the generated typescript file will be produce in the directory
     watch: string; // if specified watches all files in this directory for changes. 
     amdloader: string;  // if specified creates a js file to load all the generated typescript files in order using requirejs + order
     templateCache: {
@@ -58,4 +59,5 @@ interface ITaskOptions {
 
     htmlModuleTemplate: string;
     htmlVarTemplate: string;
+    htmlOutDir: string;
 }

--- a/tasks/ts.js
+++ b/tasks/ts.js
@@ -99,6 +99,7 @@ function pluginFn(grunt) {
             htmlModuleTemplate: '<%= filename %>',
             htmlVarTemplate: '<%= ext %>',
             htmlOutDir: null,
+            htmlOutDirFlatten: false,
             failOnTypeErrors: true
         });
 
@@ -110,6 +111,7 @@ function pluginFn(grunt) {
         options.htmlModuleTemplate = rawTargetOptions.htmlModuleTemplate || rawTaskOptions.htmlModuleTemplate;
         options.htmlVarTemplate = rawTargetOptions.htmlVarTemplate || rawTaskOptions.htmlVarTemplate;
         options.htmlOutDir = rawTargetConfig.htmlOutDir;
+        options.htmlOutDirFlatten = rawTargetConfig.htmlOutDirFlatten;
 
         // fix the properly cased options to their appropriate values
         options.allowBool = 'allowbool' in options ? options['allowbool'] : options.allowBool;
@@ -162,6 +164,11 @@ function pluginFn(grunt) {
         if (!options.htmlOutDir) {
             // use default value
             options.htmlOutDir = null;
+        }
+
+        if (!options.htmlOutDirFlatten) {
+            // use default value
+            options.htmlOutDirFlatten = false;
         }
 
         // Remove comments based on the removeComments flag first then based on the comments flag, otherwise true
@@ -385,7 +392,8 @@ function pluginFn(grunt) {
                     var html2tsOptions = {
                         moduleFunction: _.template(options.htmlModuleTemplate),
                         varFunction: _.template(options.htmlVarTemplate),
-                        htmlOutDir: options.htmlOutDir
+                        htmlOutDir: options.htmlOutDir,
+                        flatten: options.htmlOutDirFlatten
                     };
 
                     var htmlFiles = grunt.file.expand(currenttask.data.html);

--- a/tasks/ts.js
+++ b/tasks/ts.js
@@ -98,6 +98,7 @@ function pluginFn(grunt) {
             compiler: '',
             htmlModuleTemplate: '<%= filename %>',
             htmlVarTemplate: '<%= ext %>',
+            htmlOutDir: null,
             failOnTypeErrors: true
         });
 
@@ -108,6 +109,7 @@ function pluginFn(grunt) {
 
         options.htmlModuleTemplate = rawTargetOptions.htmlModuleTemplate || rawTaskOptions.htmlModuleTemplate;
         options.htmlVarTemplate = rawTargetOptions.htmlVarTemplate || rawTaskOptions.htmlVarTemplate;
+        options.htmlOutDir = rawTargetConfig.htmlOutDir;
 
         // fix the properly cased options to their appropriate values
         options.allowBool = 'allowbool' in options ? options['allowbool'] : options.allowBool;
@@ -155,6 +157,11 @@ function pluginFn(grunt) {
         if (!options.htmlVarTemplate) {
             // use default value
             options.htmlVarTemplate = '<%= ext %>';
+        }
+
+        if (!options.htmlOutDir) {
+            // use default value
+            options.htmlOutDir = null;
         }
 
         // Remove comments based on the removeComments flag first then based on the comments flag, otherwise true
@@ -377,7 +384,8 @@ function pluginFn(grunt) {
                 if (currenttask.data.html) {
                     var html2tsOptions = {
                         moduleFunction: _.template(options.htmlModuleTemplate),
-                        varFunction: _.template(options.htmlVarTemplate)
+                        varFunction: _.template(options.htmlVarTemplate),
+                        htmlOutDir: options.htmlOutDir
                     };
 
                     var htmlFiles = grunt.file.expand(currenttask.data.html);

--- a/tasks/ts.ts
+++ b/tasks/ts.ts
@@ -113,6 +113,7 @@ function pluginFn(grunt: IGrunt) {
             htmlModuleTemplate: '<%= filename %>',
             htmlVarTemplate: '<%= ext %>',
             htmlOutDir: null,
+            htmlOutDirFlatten: false,
             failOnTypeErrors: true,
         });
 
@@ -124,6 +125,7 @@ function pluginFn(grunt: IGrunt) {
         options.htmlModuleTemplate = rawTargetOptions.htmlModuleTemplate || rawTaskOptions.htmlModuleTemplate;
         options.htmlVarTemplate = rawTargetOptions.htmlVarTemplate || rawTaskOptions.htmlVarTemplate;
         options.htmlOutDir = rawTargetConfig.htmlOutDir;
+        options.htmlOutDirFlatten = rawTargetConfig.htmlOutDirFlatten;
 
         // fix the properly cased options to their appropriate values
         options.allowBool = 'allowbool' in options ? options['allowbool'] : options.allowBool;
@@ -180,6 +182,11 @@ function pluginFn(grunt: IGrunt) {
         if (!options.htmlOutDir) {
             // use default value
             options.htmlOutDir = null;
+        }
+
+        if (!options.htmlOutDirFlatten) {
+            // use default value
+            options.htmlOutDirFlatten = false;
         }
 
         // Remove comments based on the removeComments flag first then based on the comments flag, otherwise true
@@ -418,7 +425,8 @@ function pluginFn(grunt: IGrunt) {
                     var html2tsOptions = {
                         moduleFunction: _.template(options.htmlModuleTemplate),
                         varFunction: _.template(options.htmlVarTemplate),
-                        htmlOutDir: options.htmlOutDir
+                        htmlOutDir: options.htmlOutDir,
+                        flatten: options.htmlOutDirFlatten
                     };
 
                     var htmlFiles = grunt.file.expand(currenttask.data.html);

--- a/tasks/ts.ts
+++ b/tasks/ts.ts
@@ -112,6 +112,7 @@ function pluginFn(grunt: IGrunt) {
             compiler: '',
             htmlModuleTemplate: '<%= filename %>',
             htmlVarTemplate: '<%= ext %>',
+            htmlOutDir: null,
             failOnTypeErrors: true,
         });
 
@@ -122,6 +123,7 @@ function pluginFn(grunt: IGrunt) {
 
         options.htmlModuleTemplate = rawTargetOptions.htmlModuleTemplate || rawTaskOptions.htmlModuleTemplate;
         options.htmlVarTemplate = rawTargetOptions.htmlVarTemplate || rawTaskOptions.htmlVarTemplate;
+        options.htmlOutDir = rawTargetConfig.htmlOutDir;
 
         // fix the properly cased options to their appropriate values
         options.allowBool = 'allowbool' in options ? options['allowbool'] : options.allowBool;
@@ -173,6 +175,11 @@ function pluginFn(grunt: IGrunt) {
         if (!options.htmlVarTemplate) {
             // use default value
             options.htmlVarTemplate = '<%= ext %>';
+        }
+
+        if (!options.htmlOutDir) {
+            // use default value
+            options.htmlOutDir = null;
         }
 
         // Remove comments based on the removeComments flag first then based on the comments flag, otherwise true
@@ -410,7 +417,8 @@ function pluginFn(grunt: IGrunt) {
                 if (currenttask.data.html) {
                     var html2tsOptions = {
                         moduleFunction: _.template(options.htmlModuleTemplate),
-                        varFunction: _.template(options.htmlVarTemplate)
+                        varFunction: _.template(options.htmlVarTemplate),
+                        htmlOutDir: options.htmlOutDir
                     };
 
                     var htmlFiles = grunt.file.expand(currenttask.data.html);

--- a/test/htmlOutDir/reference.ts
+++ b/test/htmlOutDir/reference.ts
@@ -1,0 +1,5 @@
+//grunt-start
+/// <reference path="src/test.tpl.html.ts" />
+/// <reference path="src/bar.ts" />
+/// <reference path="src/foo.ts" />
+//grunt-end

--- a/test/htmlOutDir/reference.ts
+++ b/test/htmlOutDir/reference.ts
@@ -1,5 +1,5 @@
 //grunt-start
-/// <reference path="src/test.tpl.html.ts" />
+/// <reference path="generated/test.tpl.html.ts" />
 /// <reference path="src/bar.ts" />
 /// <reference path="src/foo.ts" />
 //grunt-end

--- a/test/htmlOutDir/src/bar.ts
+++ b/test/htmlOutDir/src/bar.ts
@@ -1,0 +1,3 @@
+/// <reference path="../reference.ts"/>
+
+var boo = test.tpl.html;

--- a/test/htmlOutDir/src/test.tpl.html
+++ b/test/htmlOutDir/src/test.tpl.html
@@ -1,0 +1,2 @@
+<div> Some content </div>
+    <span> some other content </span> 

--- a/test/htmlOutDirFlat/reference.ts
+++ b/test/htmlOutDirFlat/reference.ts
@@ -1,5 +1,5 @@
 //grunt-start
-/// <reference path="generated/test/htmlOutDir/src/test.tpl.html.ts" />
+/// <reference path="generated/test.tpl.html.ts" />
 /// <reference path="src/bar.ts" />
 /// <reference path="src/foo.ts" />
 //grunt-end

--- a/test/htmlOutDirFlat/src/bar.ts
+++ b/test/htmlOutDirFlat/src/bar.ts
@@ -1,0 +1,3 @@
+/// <reference path="../reference.ts"/>
+
+var boo = test.tpl.html;

--- a/test/htmlOutDirFlat/src/test.tpl.html
+++ b/test/htmlOutDirFlat/src/test.tpl.html
@@ -1,0 +1,2 @@
+<div> Some content </div>
+    <span> some other content </span> 


### PR DESCRIPTION
Hi,
I need to be able to have my generated .html.ts file stored in a separate directory from the original template html files. My solution is to provide a htmlOutDir option, where all the generated files are stored.
```javascript
            htmlWithHtmlOutDirTest: {
                test: true,
                src: ['test/htmlOutDir/reference.ts','test/htmlOutDir/src/bar.ts',
                    'test/htmlOutDir/src/foo.ts',
                    'test/htmlOutDir/generated/**/*.ts'],
                html: ['test/htmlOutDir/**/*.tpl.html'],
                reference: 'test/htmlOutDir/reference.ts',
                htmlOutDir: 'test/htmlOutDir/generated',
                out: 'test/htmlOutDir/out.js'
            },
```

One criticism I have of my own solution is that the files are stored flat (all in the same directory) so collisions may occur. I would be happy to hear any alternatives/alterations to my solution