### PR TITLE
Replace uses of os.EOL with grunt.util.linefeed

### DIFF
--- a/tasks/modules/amdLoader.js
+++ b/tasks/modules/amdLoader.js
@@ -3,11 +3,10 @@ var _ = require('lodash');
 var _str = require('underscore.string');
 var path = require('path');
 var fs = require('fs');
-var os = require('os');
 
 var utils = require('./utils');
 
-var eol = os.EOL;
+var eol = utils.eol;
 var grunt = utils.grunt;
 var pathSeperator = path.sep;
 

--- a/tasks/modules/amdLoader.ts
+++ b/tasks/modules/amdLoader.ts
@@ -4,11 +4,10 @@ import _ = require('lodash');
 import _str = require('underscore.string');
 import path = require('path');
 import fs = require('fs');
-import os = require('os');
 
 import utils = require('./utils');
 
-var eol = os.EOL;
+var eol = utils.eol;
 var grunt = utils.grunt;
 var pathSeperator = path.sep;
 

--- a/tasks/modules/reference.js
+++ b/tasks/modules/reference.js
@@ -5,7 +5,6 @@ var fs = require('fs');
 var grunt = require('grunt');
 
 var utils = require('./utils');
-var os = require('os');
 
 /////////////////////////////////////////////////////////////////////
 // Reference file logic
@@ -95,7 +94,7 @@ function updateReferenceFile(files, generatedFiles, referenceFile, referencePath
     contents.push(ourSignatureEnd);
 
     var updatedFileLines = utils.insertArrayAt(origFileLines, signatureSectionPosition, contents);
-    var updatedFileContents = updatedFileLines.join(os.EOL);
+    var updatedFileContents = updatedFileLines.join(utils.eol);
 
     // Modify the orig contents to put in our contents only if changed
     // Also Return whether the file was changed

--- a/tasks/modules/reference.ts
+++ b/tasks/modules/reference.ts
@@ -6,7 +6,6 @@ import fs = require('fs');
 import grunt = require('grunt');
 
 import utils = require('./utils');
-import os = require('os');
 
 /////////////////////////////////////////////////////////////////////
 // Reference file logic
@@ -96,7 +95,7 @@ export function updateReferenceFile(files: string[], generatedFiles: string[], r
     contents.push(ourSignatureEnd);
 
     var updatedFileLines = utils.insertArrayAt(origFileLines, signatureSectionPosition, contents);
-    var updatedFileContents = updatedFileLines.join(os.EOL);
+    var updatedFileContents = updatedFileLines.join(utils.eol);
 
     // Modify the orig contents to put in our contents only if changed
     // Also Return whether the file was changed

--- a/tasks/modules/templateCache.js
+++ b/tasks/modules/templateCache.js
@@ -2,11 +2,10 @@
 var _ = require('lodash');
 var fs = require('fs');
 var path = require('path');
-var os = require('os');
 
 var utils = require('./utils');
 
-var eol = os.EOL;
+var eol = utils.eol;
 
 /////////////////////////////////////////////////////////////////////
 // AngularJS templateCache

--- a/tasks/modules/templateCache.ts
+++ b/tasks/modules/templateCache.ts
@@ -3,11 +3,10 @@
 import _ = require('lodash');
 import fs = require('fs');
 import path = require('path');
-import os = require('os');
 
 import utils = require('./utils');
 
-var eol = os.EOL;
+var eol = utils.eol;
 
 
 /////////////////////////////////////////////////////////////////////

--- a/tasks/modules/transformers.js
+++ b/tasks/modules/transformers.js
@@ -11,7 +11,6 @@ var path = require('path');
 var grunt = require('grunt');
 var _str = require('underscore.string');
 var _ = require('lodash');
-var os = require('os');
 var utils = require('./utils');
 
 // Setup when transformers are triggered
@@ -159,7 +158,7 @@ var ExportTransformer = (function (_super) {
     function ExportTransformer() {
         // This code is same as import transformer
         // One difference : we do not short circuit to `index.ts` if found
-        _super.call(this, 'export', '<fileOrDirectoryName>[,<variableName>]', _.template('import <%=filename%>_file = require(\'<%= pathToFile %>\'); <%= signatureGenerated %>' + os.EOL + 'export var <%=filename%> = <%=filename%>_file;'), false, true);
+        _super.call(this, 'export', '<fileOrDirectoryName>[,<variableName>]', _.template('import <%=filename%>_file = require(\'<%= pathToFile %>\'); <%= signatureGenerated %>' + utils.eol + 'export var <%=filename%> = <%=filename%>_file;'), false, true);
     }
     return ExportTransformer;
 })(BaseImportExportTransformer);
@@ -246,7 +245,7 @@ function transformFiles(changedFiles, targetFiles, target, task) {
             // Lines not generated or not directives
             outputLines.push(line);
         }
-        var transformedContent = outputLines.join(os.EOL);
+        var transformedContent = outputLines.join(utils.eol);
         if (transformedContent !== contents) {
             grunt.file.write(fileToProcess, transformedContent);
         }

--- a/tasks/modules/transformers.ts
+++ b/tasks/modules/transformers.ts
@@ -6,7 +6,6 @@ import path = require('path');
 import grunt = require('grunt');
 import _str = require('underscore.string');
 import _ = require('lodash');
-import os = require('os');
 import utils = require('./utils');
 
 // Setup when transformers are triggered
@@ -186,7 +185,7 @@ class ExportTransformer extends BaseImportExportTransformer implements ITransfor
         // One difference : we do not short circuit to `index.ts` if found
         super('export', '<fileOrDirectoryName>[,<variableName>]',
             // workaround for https://github.com/Microsoft/TypeScript/issues/512
-            _.template('import <%=filename%>_file = require(\'<%= pathToFile %>\'); <%= signatureGenerated %>' + os.EOL +
+            _.template('import <%=filename%>_file = require(\'<%= pathToFile %>\'); <%= signatureGenerated %>' + utils.eol +
                 'export var <%=filename%> = <%=filename%>_file;'), false, true);
     }
 }
@@ -278,7 +277,7 @@ export function transformFiles(
             // Lines not generated or not directives
             outputLines.push(line);
         }
-        var transformedContent = outputLines.join(os.EOL);
+        var transformedContent = outputLines.join(utils.eol);
         if (transformedContent !== contents) {
             grunt.file.write(fileToProcess, transformedContent);
         }

--- a/tasks/modules/utils.js
+++ b/tasks/modules/utils.js
@@ -4,6 +4,7 @@ var fs = require('fs');
 var util = require('util');
 
 exports.grunt = require('grunt');
+exports.eol = exports.grunt.util.linefeed;
 
 // Converts "C:\boo" , "C:\boo\foo.ts" => "./foo.ts"; Works on unix as well.
 function makeRelativePath(folderpath, filename, forceRelative) {

--- a/tasks/modules/utils.ts
+++ b/tasks/modules/utils.ts
@@ -5,6 +5,7 @@ import fs = require('fs');
 import util = require('util');
 
 export var grunt: IGrunt = require('grunt');
+export var eol: string = grunt.util.linefeed;
 
 // Converts "C:\boo" , "C:\boo\foo.ts" => "./foo.ts"; Works on unix as well.
 export function makeRelativePath(folderpath: string, filename: string, forceRelative = false) {

--- a/test/htmlOutDir/reference.ts
+++ b/test/htmlOutDir/reference.ts
@@ -1,5 +1,5 @@
 //grunt-start
-/// <reference path="generated/test/htmlOutDir/src/test.tpl.html.ts" />
+/// <reference path="src/test.tpl.html.ts" />
 /// <reference path="src/bar.ts" />
 /// <reference path="src/foo.ts" />
 //grunt-end

--- a/test/htmlOutDirFlat/reference.ts
+++ b/test/htmlOutDirFlat/reference.ts
@@ -1,5 +1,5 @@
 //grunt-start
-/// <reference path="generated/test.tpl.html.ts" />
+/// <reference path="src/test.tpl.html.ts" />
 /// <reference path="src/bar.ts" />
 /// <reference path="src/foo.ts" />
 //grunt-end


### PR DESCRIPTION
I abstracted out the call to grunt.util.linefeed to a single variable in utils.ts to make it easy to maintain later so if grunt were to change the parameter name or if you wanted to make a user option, you would only need to change the code in one place. Besides running all the tests, I also tested it in one of my repos and confirmed I was able to get LF endings when running a grunt-ts task on Windows.