### PR TITLE
Removed unneeded commas.

### DIFF
--- a/sample/Gruntfile.js
+++ b/sample/Gruntfile.js
@@ -31,10 +31,10 @@ module.exports = function (grunt) {
                 watch: 'app',                  // If specified, watches this directory for changes, and re-runs the current target
                 // use to override the grunt-ts project options above for this target
                 options: {
-                    module: 'commonjs',
-                },
+                    module: 'commonjs'
+                }
             }
-        },
+        }
     });
     
     grunt.loadNpmTasks("grunt-ts");


### PR DESCRIPTION
The sample Gruntfile includes commas which are not needed. The WebStorm IDE issues warnings because of the unneeded comes. That's why I removed them.