### PR TITLE
Add support for file names with multiple periods on them.

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -327,6 +327,17 @@ module.exports = function (grunt) {
                 reference: 'test/html/reference.ts',
                 out: 'test/html/out.js',
             },
+            htmltestWithTemplate: {
+                test: true,
+                src: ['test/htmlTemplate/**/*.ts'],
+                html: ['test/htmlTemplate/**/*.tpl.html'],
+                reference: 'test/htmlTemplate/reference.ts',
+                out: 'test/htmlTemplate/out.js',
+                options: {
+                    htmlModuleTemplate: '<%= filename %>_<%= ext %>_module',
+                    htmlVarTemplate: '<%= filename %>_<%= ext %>_variable'
+                },
+            },
             htmlWithHtmlOutDirTest: {
                 test: true,
                 src: ['test/htmlOutDir/reference.ts','test/htmlOutDir/src/bar.ts',

--- a/tasks/modules/html2ts.js
+++ b/tasks/modules/html2ts.js
@@ -30,7 +30,7 @@ function compileHTML(filename, options) {
     var ext = path.extname(filename).replace('.', '');
     var extFreename = path.basename(filename, '.' + ext);
     var moduleName = options.moduleFunction({ ext: ext, filename: extFreename });
-    var varName = options.varFunction({ ext: ext, filename: extFreename }).replace('.', '_');
+    var varName = options.varFunction({ ext: ext, filename: extFreename }).replace(/\./g, '_');
     var fileContent = htmlTemplate({ modulename: moduleName, varname: varName, content: htmlContent });
     // Write the content to a file
     var outputfile = getOutputFile(filename, options.htmlOutDir, options.flatten);

--- a/tasks/modules/html2ts.ts
+++ b/tasks/modules/html2ts.ts
@@ -46,7 +46,7 @@ export function compileHTML(filename: string, options: IHtml2TSOptions): string 
     var extFreename = path.basename(filename, '.' + ext);
 
     var moduleName = options.moduleFunction({ ext: ext, filename: extFreename });
-    var varName = options.varFunction({ ext: ext, filename: extFreename }).replace('.', '_');
+    var varName = options.varFunction({ ext: ext, filename: extFreename }).replace(/\./g, '_');
 
     var fileContent = htmlTemplate({ modulename: moduleName, varname: varName, content: htmlContent });
 

--- a/test/expected/htmlTemplate/out.js
+++ b/test/expected/htmlTemplate/out.js
@@ -1,0 +1,15 @@
+var advanced;
+(function (advanced) {
+    var $$template;
+    (function ($$template) {
+        var name;
+        (function (name) {
+            var tpl_html_module;
+            (function (tpl_html_module) {
+                tpl_html_module.advanced_$$template_name_tpl_html_variable = '<div> Some content </div>    <span> some other content </span> ';
+            })(tpl_html_module = name.tpl_html_module || (name.tpl_html_module = {}));
+        })(name = $$template.name || ($$template.name = {}));
+    })($$template = advanced.$$template || (advanced.$$template = {}));
+})(advanced || (advanced = {}));
+var boo = advanced.$$template.name.tpl_html_module.advanced_$$template_name_tpl_html_variable;
+//# sourceMappingURL=out.js.map

--- a/test/htmlTemplate/src/advanced.$$template.name.tpl.html
+++ b/test/htmlTemplate/src/advanced.$$template.name.tpl.html
@@ -1,0 +1,2 @@
+<div> Some content </div>
+    <span> some other content </span> 

--- a/test/htmlTemplate/src/foo.ts
+++ b/test/htmlTemplate/src/foo.ts
@@ -1,0 +1,3 @@
+/// <reference path="../reference.ts"/>
+
+var boo = advanced.$$template.name.tpl_html_module.advanced_$$template_name_tpl_html_variable;

--- a/test/test.js
+++ b/test/test.js
@@ -6,7 +6,9 @@ function testFile(test, path) {
     var actualFileName = 'test/' + path, expectedFileName = 'test/expected/' + path;
     var actual = grunt.file.read(actualFileName);
     var expected = grunt.file.read(expectedFileName);
-    test.equal(expected, actual, 'Actual did not match expected:' + grunt.util.linefeed + actualFileName + grunt.util.linefeed + expectedFileName);
+    test.equal(expected, actual, 'Actual did not match expected:' + grunt.util.linefeed +
+        actualFileName + grunt.util.linefeed +
+        expectedFileName);
 }
 function assertFileDoesNotExist(test, path) {
     var exists = grunt.file.exists(path);
@@ -16,7 +18,9 @@ function testExpectedFile(test, path) {
     var actualFileName = path.replace('\\expected', '').replace('/expected', ''), expectedFileName = path;
     var actual = grunt.file.read(actualFileName);
     var expected = grunt.file.read(expectedFileName);
-    test.equal(expected, actual, 'Actual did not match expected:' + grunt.util.linefeed + actualFileName + grunt.util.linefeed + expectedFileName);
+    test.equal(expected, actual, 'Actual did not match expected:' + grunt.util.linefeed +
+        actualFileName + grunt.util.linefeed +
+        expectedFileName);
 }
 function testDirectory(test, folder) {
     var files = utils.getFiles(('test/expected/' + folder));
@@ -45,6 +49,7 @@ exports.typescript = {
     },
     html2ts: function (test) {
         testDirectory(test, 'html');
+        testDirectory(test, 'htmlTemplate');
         test.done();
     },
     index: function (test) {

--- a/test/test.ts
+++ b/test/test.ts
@@ -61,6 +61,7 @@ export var typescript = {
     },
     html2ts: function (test) {
         testDirectory(test, 'html');
+        testDirectory(test, 'htmlTemplate');
         test.done();
     },
     index: function (test) {


### PR DESCRIPTION
When compiling html files with names containing periods, the compile function creates invalid ts output.

Options used:
```
options: {
  htmlModuleTemplate: 'Templates',
  htmlVarTemplate: '<%= filename %>_<%= ext %>'
}
```

Example:
``test.view.example.index.html`` -> ``test.view.example.index.html.ts``

Outputs ``test.view.example.index.html.ts``:
```
module mctUntitledAppTemplates_Dev { export var test_view.example.index_html =  '<html><body>Hello world' }
```

Which then causes a compile error:
```
test.view.example.index.html.ts(1,58): error TS1005: ',' expected.
test.view.example.index.html.ts(1,66): error TS1005: ',' expected.
```

This commit includes a basic fix by replacing all occurrences of ``'\.'``. Note that it might be a good idea to replace other special js characters.

I have too many files with this naming scheme, so a fix would be great. Thank you!