### PR TITLE
Issues #236 - Fix for use of local node binaries.

### DIFF
--- a/tasks-internal/modules/compile.js
+++ b/tasks-internal/modules/compile.js
@@ -13,7 +13,7 @@ exports.grunt = require('grunt');
 function executeNode(args) {
     return new Promise(function (resolve, reject) {
         exports.grunt.util.spawn({
-            cmd: 'node',
+            cmd: process.execPath,
             args: args
         }, function (error, result, code) {
             var ret = {

--- a/tasks-internal/modules/compile.ts
+++ b/tasks-internal/modules/compile.ts
@@ -22,7 +22,7 @@ export interface ICompileResult {
 function executeNode(args: string[]): Promise<ICompileResult> {
     return new Promise((resolve, reject) => {
         grunt.util.spawn({
-            cmd: 'node',
+            cmd: process.execPath,
             args: args
         }, (error, result, code) => {
                 var ret: ICompileResult = {

--- a/tasks/modules/compile.js
+++ b/tasks/modules/compile.js
@@ -13,7 +13,7 @@ exports.grunt = require('grunt');
 function executeNode(args) {
     return new Promise(function (resolve, reject) {
         exports.grunt.util.spawn({
-            cmd: 'node',
+            cmd: process.execPath,
             args: args
         }, function (error, result, code) {
             var ret = {

--- a/tasks/modules/compile.ts
+++ b/tasks/modules/compile.ts
@@ -22,7 +22,7 @@ export interface ICompileResult {
 function executeNode(args: string[]): Promise<ICompileResult> {
     return new Promise((resolve, reject) => {
         grunt.util.spawn({
-            cmd: 'node',
+            cmd: process.execPath,
             args: args
         }, (error, result, code) => {
                 var ret: ICompileResult = {


### PR DESCRIPTION
 Modified the executeNode(...) helper in the compile module. Changed the value of cmd from the hardcoded string 'node' to the process.execPath value.