### PR TITLE
Allow the use of sub dirs + no quotes for imported HTML

### DIFF
--- a/tasks/modules/html2ts.js
+++ b/tasks/modules/html2ts.js
@@ -37,6 +37,7 @@ function compileHTML(filename, options) {
     if (options.cwd) {
         extFreename = extFreename.replace(options.cwd.replace(/\//g, '.'), '');
     }
+    var moduleName = options.moduleFunction({ ext: ext, filename: extFreename });
     var varName = options.varFunction({ ext: ext, filename: extFreename }).replace(/\./g, '_');
     if (options.useQuotes) {
         var fileContent = htmlTemplate({ modulename: moduleName, varname: varName, content: htmlContent });

--- a/tasks/modules/html2ts.js
+++ b/tasks/modules/html2ts.js
@@ -23,6 +23,7 @@ function stripBOM(str) {
     return 0xFEFF === str.charCodeAt(0) ? str.substring(1) : str;
 }
 var htmlTemplate = _.template('/* tslint:disable:max-line-length */' + utils.eol + 'module <%= modulename %> {' + utils.eol + '  export var <%= varname %> = \'<%= content %>\';' + utils.eol + '}' + utils.eol);
+var htmlTemplateWithoutQuotes = _.template('/* tslint:disable:max-line-length */' + utils.eol + 'module <%= modulename %> {' + utils.eol + '  export var <%= varname %> = <%= content %>;' + utils.eol + '}' + utils.eol);
 // Compile an HTML file to a TS file
 // Return the filename. This filename will be required by reference.ts
 function compileHTML(filename, options) {
@@ -32,9 +33,16 @@ function compileHTML(filename, options) {
     // TODO: place a minification pipeline here if you want.
     var ext = path.extname(filename).replace('.', '');
     var extFreename = path.basename(filename, '.' + ext);
-    var moduleName = options.moduleFunction({ ext: ext, filename: extFreename });
+    extFreename = path.dirname(filename).replace(/\//g, '.') + '.' + extFreename;
+    if (options.cwd) {
+        extFreename = extFreename.replace(options.cwd.replace(/\//g, '.'), '');
+    }
     var varName = options.varFunction({ ext: ext, filename: extFreename }).replace(/\./g, '_');
-    var fileContent = htmlTemplate({ modulename: moduleName, varname: varName, content: htmlContent });
+    if (options.useQuotes) {
+        var fileContent = htmlTemplate({ modulename: moduleName, varname: varName, content: htmlContent });
+    } else {
+        var fileContent = htmlTemplateWithoutQuotes({ modulename: moduleName, varname: varName, content: htmlContent });
+    }
     // Write the content to a file
     var outputfile = getOutputFile(filename, options.htmlOutDir, options.flatten);
     mkdirParent(path.dirname(outputfile));

--- a/tasks/ts.js
+++ b/tasks/ts.js
@@ -204,10 +204,6 @@ function pluginFn(grunt) {
                 // use default value
                 options.htmlCwd = '';
             }
-            if (!options.htmlUseQuotesForContent) {
-                // use default value
-                options.htmlUseQuotesForContent = true;
-            }
             if (!options.htmlModuleTemplate) {
                 // use default value
                 options.htmlModuleTemplate = '<%= filename %>';

--- a/tasks/ts.js
+++ b/tasks/ts.js
@@ -87,6 +87,8 @@ function pluginFn(grunt) {
             verbose: false,
             fast: 'watch',
             compiler: '',
+            htmlCwd: '',
+            htmlUseQuotesForContent: true,
             htmlModuleTemplate: '<%= filename %>',
             htmlVarTemplate: '<%= ext %>',
             htmlOutDir: null,
@@ -173,6 +175,8 @@ function pluginFn(grunt) {
                     }
                 }
             }
+            options.htmlCwd = rawTargetOptions.htmlCwd || rawTaskOptions.htmlCwd;
+            options.htmlUseQuotesForContent = rawTargetOptions.htmlUseQuotesForContent || rawTaskOptions.htmlUseQuotesForContent;
             options.htmlModuleTemplate = rawTargetOptions.htmlModuleTemplate || rawTaskOptions.htmlModuleTemplate;
             options.htmlVarTemplate = rawTargetOptions.htmlVarTemplate || rawTaskOptions.htmlVarTemplate;
             options.htmlOutDir = rawTargetConfig.htmlOutDir;
@@ -196,6 +200,14 @@ function pluginFn(grunt) {
                 options.fast = 'never';
             }
             logBadConfigWithFiles(rawTargetConfig, currenttask, rawTargetOptions);
+            if (!options.htmlCwd) {
+                // use default value
+                options.htmlCwd = '';
+            }
+            if (!options.htmlUseQuotesForContent) {
+                // use default value
+                options.htmlUseQuotesForContent = true;
+            }
             if (!options.htmlModuleTemplate) {
                 // use default value
                 options.htmlModuleTemplate = '<%= filename %>';
@@ -430,6 +442,8 @@ function pluginFn(grunt) {
                     var generatedFiles = [];
                     if (currenttask.data.html) {
                         var html2tsOptions = {
+                            cwd: options.htmlCwd,
+                            useQuotes: options.htmlUseQuotesForContent,
                             moduleFunction: _.template(options.htmlModuleTemplate),
                             varFunction: _.template(options.htmlVarTemplate),
                             htmlOutDir: options.htmlOutDir,


### PR DESCRIPTION
This is usefull when you have something like

app/templates/page1/section1.html
app/templates/page1/section2.html

and you want to do something like HTML.page1.section1;

Also, we're using React and this is very helpful with the JSX compiler. 
We use app/JSX/page1/Comp1.jsx
which gets transformed into Comp1.js
which gets imported into TS via your plugin. But we don't want to import as "React.createElement..." rather than React.createElement (no quotes).