### PR TITLE
Adding support for HTML templates as external modules

### DIFF
--- a/README.md
+++ b/README.md
@@ -569,11 +569,12 @@ grunt.initConfig({
         //HTML template objects will expose their content via a property called markup.
         htmlVarTemplate: 'markup',
         htmlModuleTemplate: 'html',
-        htmlOutputTemplate: '/* tslint:disable:max-line-length */' '\n' +
-          'export module <%= modulename %> {' + '\n' +
-          '  export var <%= varname %> = \'<%= content %>\';' + '\n' +
-          '}' + '\n'
+        htmlOutputTemplate: '/* tslint:disable:max-line-length */ \n\
+          export module <%= modulename %> {\n\
+              export var <%= varname %> = \'<%= content %>\';\n\
+          }\n'
       }
+
     }
   }
 });

--- a/README.md
+++ b/README.md
@@ -550,6 +550,35 @@ grunt.initConfig({
 });
 ````
 
+#### htmlOutputTemplate
+
+Grunt-ts supports compilation of `.html` file content to TypeScript variables which is explained in detail [here](/docs/html2ts.md).  The `htmlOutputTemplate` target property allows the developer to override the internally defined output template to a custom one, useful if one would like to define the HTML output as an external modules, for example. 
+Three variables can be used in this template, namely:
+
+
+* "<%= modulename %>" - This variable will be interpolated with the value of the htmlModuleTemplate option
+* "<%= varname %>" - This variable will be interpolated with the value of the htmlVarTemplate option
+* "<%= content %>" - This variable will be interpolated with the content of the HTML file
+
+````javascript
+//Note: Outputs an external module
+grunt.initConfig({
+  ts: {
+    default: {
+      options: {
+        //HTML template objects will expose their content via a property called markup.
+        htmlVarTemplate: 'markup',
+        htmlModuleTemplate: 'html',
+        htmlOutputTemplate: '/* tslint:disable:max-line-length */' '\n' +
+          'export module <%= modulename %> {' + '\n' +
+          '  export var <%= varname %> = \'<%= content %>\';' + '\n' +
+          '}' + '\n'
+      }
+    }
+  }
+});
+````
+
 #### mapRoot
 
 Specifies the root for where `.js.map` sourcemap files should be referenced.  This is useful if you intend to move your `.js.map` files to a different location.  Leave this blank or omit entirely if the `.js.map` files will be deployed to the same folder as the corresponding `.js` files.  See also [sourceRoot](#sourceroot).

--- a/docs/html2ts.md
+++ b/docs/html2ts.md
@@ -26,7 +26,7 @@ Specifically: http://stackoverflow.com/a/9867375/390330
 
 #### Control generated TypeScript module and variable names
 
-In the task options `htmlModuleTemplate` and `htmlVarTemplate` you can specify Underscore templates to be used in order to generate the module and variable names for the generated TypeScript.
+In the task options `htmlModuleTemplate` and `htmlVarTemplate` you can specify Underscore template variables to be used in order to generate the module and variable names for the generated TypeScript.
 
 Those Underscore template receive the following parameters:
 
@@ -42,6 +42,58 @@ Usage example is setting the module template to "MyModule.Templates" and the var
 ```typescript
 module MyModule.Templates { export var test = '<div Some content </div>' }
 ```
+
+#### Override predefined template and specify a custom output format
+
+Using the task option `htmlOutputTemplate` you can specify Underscore template strings to be used against interpolation with three variables:
+
+* "<%= modulename %>" - This variable will be interpolated with the value of the htmlModuleTemplate option
+* "<%= varname %>" - This variable will be interpolated with the value of the htmlVarTemplate option
+* "<%= content %>" - This variable will be interpolated with the content of the HTML file
+
+
+For example if we would like to specify a custom template that outputs an external module, we could use:
+
+````javascript
+//Note: Outputs an external module
+grunt.initConfig({
+  ts: {
+    default: {
+      options: {
+        //HTML template objects will expose their content via a property called markup.
+        htmlVarTemplate: 'markup',
+        htmlModuleTemplate: 'html',
+        htmlOutputTemplate: '/* tslint:disable:max-line-length */' '\n' +
+          'export module <%= modulename %> {' + '\n' +
+          '  export var <%= varname %> = \'<%= content %>\';' + '\n' +
+          '}' + '\n'
+      }
+    }
+  }
+});
+````
+
+we can then do the following in our .ts file:
+
+````typescript
+//import the external module
+import myTemplate = require('module');
+
+...
+
+//consume it
+var templateString = myTemplate.markup.html
+
+````
+
+
+If this appears as excessive object wrapping, the simplest form for htmlOutputTemplate is:
+````javascript
+/* tslint:disable:max-line-length */' '\n' +
+export var <%= modulename %>='<%= content %>';
+````
+
+export var %filename%='%content%';"
 
 #### Going further
 Primarily designed for html files, this feature can be used with any static file.

--- a/docs/html2ts.md
+++ b/docs/html2ts.md
@@ -89,7 +89,7 @@ var templateString = myTemplate.markup.html
 
 If this appears as excessive object wrapping, the simplest form for htmlOutputTemplate is:
 ````javascript
-/* tslint:disable:max-line-length */' '\n' +
+/* tslint:disable:max-line-length */' + '\n' +
 export var <%= modulename %>='<%= content %>';
 ````
 

--- a/docs/html2ts.md
+++ b/docs/html2ts.md
@@ -63,10 +63,10 @@ grunt.initConfig({
         //HTML template objects will expose their content via a property called markup.
         htmlVarTemplate: 'markup',
         htmlModuleTemplate: 'html',
-        htmlOutputTemplate: '/* tslint:disable:max-line-length */' '\n' +
-          'export module <%= modulename %> {' + '\n' +
-          '  export var <%= varname %> = \'<%= content %>\';' + '\n' +
-          '}' + '\n'
+		htmlOutputTemplate: '/* tslint:disable:max-line-length */ \n\
+          export module <%= modulename %> {\n\
+              export var <%= varname %> = \'<%= content %>\';\n\
+          }\n'
       }
     }
   }

--- a/tasks/modules/html2ts.js
+++ b/tasks/modules/html2ts.js
@@ -50,10 +50,7 @@ function compileHTML(filename, options) {
 exports.compileHTML = compileHTML;
 // Replace user-supplied templates newlines with newlines appropriate for the current OS
 function replaceNewLines(input) {
-    var output, standardized;
-    standardized = input.replace(/\r/g, '');
-    output = output.replace(/\n/g, utils.eol);
-    return output;
+    return input.replace(/\r/g, '').replace(/\n/g, utils.eol);
 }
 function getOutputFile(filename, htmlOutDir, flatten) {
     var outputfile = filename;

--- a/tasks/modules/html2ts.js
+++ b/tasks/modules/html2ts.js
@@ -22,7 +22,8 @@ var escapeContent = function (content, quoteChar) {
 function stripBOM(str) {
     return 0xFEFF === str.charCodeAt(0) ? str.substring(1) : str;
 }
-var htmlTemplate = _.template('/* tslint:disable:max-line-length */' + utils.eol + 'module <%= modulename %> {' + utils.eol + '  export var <%= varname %> = \'<%= content %>\';' + utils.eol + '}' + utils.eol);
+var htmlInternalTemplate = _.template('/* tslint:disable:max-line-length */' + utils.eol + 'module <%= modulename %> {' + utils.eol + '  export var <%= varname %> = \'<%= content %>\';' + utils.eol + '}' + utils.eol);
+var htmlExternalTemplate = _.template('/* tslint:disable:max-line-length */' + utils.eol + 'export module <%= modulename %> {' + utils.eol + '  export var <%= varname %> = \'<%= content %>\';' + utils.eol + '}' + utils.eol);
 // Compile an HTML file to a TS file
 // Return the filename. This filename will be required by reference.ts
 function compileHTML(filename, options) {
@@ -34,7 +35,13 @@ function compileHTML(filename, options) {
     var extFreename = path.basename(filename, '.' + ext);
     var moduleName = options.moduleFunction({ ext: ext, filename: extFreename });
     var varName = options.varFunction({ ext: ext, filename: extFreename }).replace(/\./g, '_');
-    var fileContent = htmlTemplate({ modulename: moduleName, varname: varName, content: htmlContent });
+    var fileContent;
+    if (options.htmlModuleFormat && options.htmlModuleFormat === 'external') {
+        fileContent = htmlExternalTemplate({ modulename: moduleName, varname: varName, content: htmlContent });
+    }
+    else {
+        fileContent = htmlInternalTemplate({ modulename: moduleName, varname: varName, content: htmlContent });
+    }
     // Write the content to a file
     var outputfile = getOutputFile(filename, options.htmlOutDir, options.flatten);
     mkdirParent(path.dirname(outputfile));

--- a/tasks/modules/html2ts.ts
+++ b/tasks/modules/html2ts.ts
@@ -29,14 +29,20 @@ function stripBOM(str) {
         : str;
 }
 
-var htmlTemplate = _.template('/* tslint:disable:max-line-length */' + utils.eol +
+var htmlInternalTemplate = _.template('/* tslint:disable:max-line-length */' + utils.eol +
     'module <%= modulename %> {' + utils.eol +
+    '  export var <%= varname %> = \'<%= content %>\';' + utils.eol +
+    '}' + utils.eol);
+
+var htmlExternalTemplate = _.template('/* tslint:disable:max-line-length */' + utils.eol +
+    'export module <%= modulename %> {' + utils.eol +
     '  export var <%= varname %> = \'<%= content %>\';' + utils.eol +
     '}' + utils.eol);
 
 export interface IHtml2TSOptions {
     moduleFunction: Function;
     varFunction: Function;
+    htmlModuleFormat: string;
     htmlOutDir: string;
     flatten: boolean;
 }
@@ -57,7 +63,12 @@ export function compileHTML(filename: string, options: IHtml2TSOptions): string 
     var moduleName = options.moduleFunction({ ext: ext, filename: extFreename });
     var varName = options.varFunction({ ext: ext, filename: extFreename }).replace(/\./g, '_');
 
-    var fileContent = htmlTemplate({ modulename: moduleName, varname: varName, content: htmlContent });
+    var fileContent;
+    if (options.htmlModuleFormat && options.htmlModuleFormat === 'external') {
+        fileContent = htmlExternalTemplate({ modulename: moduleName, varname: varName, content: htmlContent });
+    } else {
+        fileContent = htmlInternalTemplate({ modulename: moduleName, varname: varName, content: htmlContent });
+    }
 
     // Write the content to a file
     var outputfile = getOutputFile(filename, options.htmlOutDir, options.flatten);

--- a/tasks/modules/html2ts.ts
+++ b/tasks/modules/html2ts.ts
@@ -78,13 +78,9 @@ export function compileHTML(filename: string, options: IHtml2TSOptions): string 
 
 // Replace user-supplied templates newlines with newlines appropriate for the current OS
 function replaceNewLines(input: string) {
-    var output, standardized;
-
-    standardized = input.replace(/\r/g, '');
-    output = standardized.replace(/\n/g, utils.eol);
-
-    return output;
+   return input.replace(/\r/g, '').replace(/\n/g, utils.eol);
 }
+
 
 function getOutputFile(filename: string, htmlOutDir: string, flatten: boolean): string {
     var outputfile = filename;

--- a/tasks/modules/html2ts.ts
+++ b/tasks/modules/html2ts.ts
@@ -81,7 +81,7 @@ function replaceNewLines(input: string) {
     var output, standardized;
 
     standardized = input.replace(/\r/g, '');
-    output = output.replace(/\n/g, utils.eol);
+    output = standardized.replace(/\n/g, utils.eol);
 
     return output;
 }

--- a/tasks/modules/interfaces.d.ts
+++ b/tasks/modules/interfaces.d.ts
@@ -53,7 +53,7 @@ interface ITaskOptions {
     compile: boolean;
     fast: string; // never | always | watch (default)
     compiler: string; // If you want, the path to a custom TypeScript compiler's main JS file
-    htmlModuleFormat: string; // internal (default) | external
+    htmlOutputTemplate: string; // If you want you can specify your own template against which the HTML will be generated
     htmlModuleTemplate: string;
     htmlVarTemplate: string;
     htmlOutDir: string;

--- a/tasks/modules/interfaces.d.ts
+++ b/tasks/modules/interfaces.d.ts
@@ -53,6 +53,7 @@ interface ITaskOptions {
     compile: boolean;
     fast: string; // never | always | watch (default)
     compiler: string; // If you want, the path to a custom TypeScript compiler's main JS file
+    htmlModuleFormat: string; // internal (default) | external
     htmlModuleTemplate: string;
     htmlVarTemplate: string;
     htmlOutDir: string;

--- a/tasks/ts.js
+++ b/tasks/ts.js
@@ -87,6 +87,7 @@ function pluginFn(grunt) {
             verbose: false,
             fast: 'watch',
             compiler: '',
+            htmlModuleFormat: 'internal',
             htmlModuleTemplate: '<%= filename %>',
             htmlVarTemplate: '<%= ext %>',
             htmlOutDir: null,
@@ -432,6 +433,7 @@ function pluginFn(grunt) {
                         var html2tsOptions = {
                             moduleFunction: _.template(options.htmlModuleTemplate),
                             varFunction: _.template(options.htmlVarTemplate),
+                            htmlModuleFormat: options.htmlModuleFormat,
                             htmlOutDir: options.htmlOutDir,
                             flatten: options.htmlOutDirFlatten
                         };

--- a/tasks/ts.js
+++ b/tasks/ts.js
@@ -87,7 +87,7 @@ function pluginFn(grunt) {
             verbose: false,
             fast: 'watch',
             compiler: '',
-            htmlModuleFormat: 'internal',
+            htmlOutputTemplate: null,
             htmlModuleTemplate: '<%= filename %>',
             htmlVarTemplate: '<%= ext %>',
             htmlOutDir: null,
@@ -433,7 +433,7 @@ function pluginFn(grunt) {
                         var html2tsOptions = {
                             moduleFunction: _.template(options.htmlModuleTemplate),
                             varFunction: _.template(options.htmlVarTemplate),
-                            htmlModuleFormat: options.htmlModuleFormat,
+                            htmlOutputTemplate: options.htmlOutputTemplate,
                             htmlOutDir: options.htmlOutDir,
                             flatten: options.htmlOutDirFlatten
                         };

--- a/tasks/ts.js
+++ b/tasks/ts.js
@@ -174,6 +174,7 @@ function pluginFn(grunt) {
                     }
                 }
             }
+            options.htmlOutputTemplate = rawTargetOptions.htmlOutputTemplate || rawTaskOptions.htmlOutputTemplate;
             options.htmlModuleTemplate = rawTargetOptions.htmlModuleTemplate || rawTaskOptions.htmlModuleTemplate;
             options.htmlVarTemplate = rawTargetOptions.htmlVarTemplate || rawTaskOptions.htmlVarTemplate;
             options.htmlOutDir = rawTargetConfig.htmlOutDir;

--- a/tasks/ts.ts
+++ b/tasks/ts.ts
@@ -112,6 +112,7 @@ function pluginFn(grunt: IGrunt) {
             verbose: false,
             fast: 'watch',
             compiler: '',
+            htmlModuleFormat: 'internal',
             htmlModuleTemplate: '<%= filename %>',
             htmlVarTemplate: '<%= ext %>',
             htmlOutDir: null,
@@ -540,6 +541,7 @@ function pluginFn(grunt: IGrunt) {
                         var html2tsOptions = {
                             moduleFunction: _.template(options.htmlModuleTemplate),
                             varFunction: _.template(options.htmlVarTemplate),
+                            htmlModuleFormat: options.htmlModuleFormat,
                             htmlOutDir: options.htmlOutDir,
                             flatten: options.htmlOutDirFlatten
                         };

--- a/tasks/ts.ts
+++ b/tasks/ts.ts
@@ -112,7 +112,7 @@ function pluginFn(grunt: IGrunt) {
             verbose: false,
             fast: 'watch',
             compiler: '',
-            htmlModuleFormat: 'internal',
+            htmlOutputTemplate: null,
             htmlModuleTemplate: '<%= filename %>',
             htmlVarTemplate: '<%= ext %>',
             htmlOutDir: null,
@@ -541,7 +541,7 @@ function pluginFn(grunt: IGrunt) {
                         var html2tsOptions = {
                             moduleFunction: _.template(options.htmlModuleTemplate),
                             varFunction: _.template(options.htmlVarTemplate),
-                            htmlModuleFormat: options.htmlModuleFormat,
+                            htmlOutputTemplate: options.htmlOutputTemplate,
                             htmlOutDir: options.htmlOutDir,
                             flatten: options.htmlOutDirFlatten
                         };

--- a/tasks/ts.ts
+++ b/tasks/ts.ts
@@ -231,6 +231,7 @@ function pluginFn(grunt: IGrunt) {
                 }
             }
 
+            options.htmlOutputTemplate = rawTargetOptions.htmlOutputTemplate || rawTaskOptions.htmlOutputTemplate;
             options.htmlModuleTemplate = rawTargetOptions.htmlModuleTemplate || rawTaskOptions.htmlModuleTemplate;
             options.htmlVarTemplate = rawTargetOptions.htmlVarTemplate || rawTaskOptions.htmlVarTemplate;
             options.htmlOutDir = rawTargetConfig.htmlOutDir;


### PR DESCRIPTION
In reference to https://github.com/TypeStrong/grunt-ts/issues/208 .
This allows developers to define if the resulting TS will be an internal or an external module.