### PR TITLE
Support the `--emitDecoratorMetadata` compiler option.

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,7 @@ Grunt-ts supports most `tsc` switches.  Click the link to cross-reference to the
 |--sourceMap|[sourceMap](#sourcemap)|Generates corresponding `.map` file|
 |--sourceRoot LOCATION|[sourceRoot](#sourceroot)|Specifies the location where debugger should locate TypeScript files instead of source locations.|
 |--suppressImplicitAnyIndexErrors|[suppressImplicitAnyIndexErrors](#suppressimplicitanyindexerrors)|Specifies the location where debugger should locate TypeScript files instead of source locations.|
+|--emitDecoratorMetadata|[emitDecoratorMetadata](#emitDecoratorMetadata)|Emit metadata for type/parameter decorators.|
 |--target VERSION|[target](#target)|Specify ECMAScript target version: `'es3'`, `'es5'`, or `'es6'`|
 
 
@@ -751,6 +752,16 @@ var p : person = { name: "Test" };
 p["age"] = 101;  //property age does not exist on interface person.
 console.log(p["age"]);
 ````
+
+#### emitDecoratorMetadata
+
+````javascript
+true | false (default)
+````
+
+Set to true to pass `--emitDecoratorMetadata` to the compiler.  If set to true, TypeScript will emit type information about type and parameter decorators, so it's available at runtime.
+
+Used by tools like [Angular](https://angular.io/). You will probably need to import the [reflect-metadata](https://www.npmjs.com/package/reflect-metadata) package in your app when using this feature.
 
 #### target
 

--- a/tasks/modules/compile.js
+++ b/tasks/modules/compile.js
@@ -143,6 +143,9 @@ function compileAllFiles(targetFiles, target, task, targetName, outFile) {
     if (task.noEmitOnError) {
         args.push('--noEmitOnError');
     }
+    if (task.emitDecoratorMetadata) {
+        args.push('--emitDecoratorMetadata');
+    }
     if (task.preserveConstEnums) {
         args.push('--preserveConstEnums');
     }

--- a/tasks/modules/interfaces.d.ts
+++ b/tasks/modules/interfaces.d.ts
@@ -43,6 +43,7 @@ interface ITaskOptions {
     failOnTypeErrors: boolean;
     /** If a type error occurs, do not emit the JavaScript.  New in TypeScript 1.4.  */
     noEmitOnError: boolean;
+    emitDecoratorMetadata: boolean;
     /** Const enums will be kept as enums in the emitted JS. If false, the enum values will
      * look like magic numbers with a comment in the emitted JS. */
     preserveConstEnums: boolean;


### PR DESCRIPTION
Via a task.emitDecoratorMetadata property.

I needed this when compiling Angular 2.0 apps -- the DI configuration requires that compiler option.