### PR TITLE
Update package.json for TypeScript 1.6 & up

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "lodash": "2.4.1",
     "ncp": "0.5.1",
     "rimraf": "2.2.6",
-    "typescript": "1.5.3",
+    "typescript": "^1.5.3",
     "underscore": "1.5.1",
     "underscore.string": "2.3.3"
   },


### PR DESCRIPTION
TS 1.6 came out with features like extending HTMLElement, and grunt-ts won't update for it.