### PR TITLE
tsc allow use inlineSources with sourceMap option

### DIFF
--- a/tasks/modules/optionsResolver.js
+++ b/tasks/modules/optionsResolver.js
@@ -276,9 +276,6 @@ function addressAssociatedOptionsAndResolveConflicts(options) {
         options.warnings.push('TypeScript cannot use inlineSourceMap and sourceMap together.  Ignoring sourceMap.');
         options.sourceMap = false;
     }
-    if (options.inlineSources && options.sourceMap) {
-        options.errors.push('It is not permitted to use inlineSources and sourceMap together.  Use one or the other.');
-    }
     if (options.inlineSources && !options.sourceMap) {
         options.inlineSources = true;
         options.inlineSourceMap = true;

--- a/tasks/modules/optionsResolver.ts
+++ b/tasks/modules/optionsResolver.ts
@@ -325,10 +325,6 @@ function addressAssociatedOptionsAndResolveConflicts(options: IGruntTSOptions) {
     options.sourceMap = false;
   }
 
-  if (options.inlineSources && options.sourceMap) {
-    options.errors.push('It is not permitted to use inlineSources and sourceMap together.  Use one or the other.');
-  }
-
   if (options.inlineSources && !options.sourceMap) {
     options.inlineSources = true;
     options.inlineSourceMap = true;


### PR DESCRIPTION
with 
```
    "compilerOptions": {
        "module": "commonjs",
        "target": "es5",
        "noImplicitAny": true,
        "inlineSources": true
    },
```

```
$ tsc -p ./
error TS5051: Option 'inlineSources' can only be used when either option '--inlineSourceMap' or option '--sourceMap' is provided.
```
