### PR TITLE
htmlOutputTemplate bug

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -637,15 +637,16 @@ module.exports = function (grunt) {
             },
             test_htmlOutputTemplate: {
                 test: true,
-                options: {},
+                options: {
+                    htmlVarTemplate: 'html',
+                    htmlModuleTemplate: 'html.external',
+                    htmlOutputTemplate:'module <%= modulename %> {\n' +
+                    '    export var <%= varname %> = \'<%= content %>\';\n' +
+                    '}\n'
+                },
                 html: 'test/htmlExternal/**/*.html',
-                src: 'test/htmlExternal/**/*.ts',
-                htmlVarTemplate: 'markup',
-                htmlModuleTemplate: 'html',
-                htmlOutputTemplate: '/* tslint:disable:max-line-length */ \n' +
-                'export module <%= modulename %> {\n' +
-                '    export var <%= varname %> = \'<%= content %>\';\n' +
-                '}\n'
+                src: 'test/htmlExternal/**/*.ts'
+                
             },
             decoratorMetadataPassed: {
                 test: true,

--- a/tasks-internal/modules/optionsResolver.js
+++ b/tasks-internal/modules/optionsResolver.js
@@ -13,7 +13,7 @@ var propertiesFromTarget = ['amdloader', 'html', 'htmlOutDir', 'htmlOutDirFlatte
     'htmlOutputTemplate', 'htmlOutDirFlatten', 'htmlVarTemplate', 'inlineSourceMap', 'inlineSources', 'isolatedModules',
     'mapRoot', 'module', 'newLine', 'noEmit', 'noEmitHelpers', 'noEmitOnError', 'noImplicitAny', 'noResolve',
     'preserveConstEnums', 'removeComments', 'sourceRoot', 'sourceMap', 'suppressImplicitAnyIndexErrors', 'target',
-    'verbose', 'jsx', 'moduleResolution', 'experimentalAsyncFunctions', 'rootDir'], delayTemplateExpansion = ['htmlModuleTemplate', 'htmlVarTemplate'];
+    'verbose', 'jsx', 'moduleResolution', 'experimentalAsyncFunctions', 'rootDir'], delayTemplateExpansion = ['htmlModuleTemplate', 'htmlVarTemplate','htmlOutputTemplate'];
 var templateProcessor = null;
 var globExpander = null;
 function noopTemplateProcessor(templateString, options) {

--- a/tasks-internal/modules/optionsResolver.ts
+++ b/tasks-internal/modules/optionsResolver.ts
@@ -18,7 +18,7 @@ const propertiesFromTarget = ['amdloader', 'html', 'htmlOutDir', 'htmlOutDirFlat
         'mapRoot', 'module', 'newLine', 'noEmit', 'noEmitHelpers', 'noEmitOnError', 'noImplicitAny', 'noResolve',
         'preserveConstEnums', 'removeComments', 'sourceRoot', 'sourceMap', 'suppressImplicitAnyIndexErrors', 'target',
         'verbose', 'jsx', 'moduleResolution', 'experimentalAsyncFunctions', 'rootDir'],
-      delayTemplateExpansion = ['htmlModuleTemplate', 'htmlVarTemplate'];
+      delayTemplateExpansion = ['htmlModuleTemplate', 'htmlVarTemplate','htmlOutputTemplate'];
 
 let templateProcessor: (templateString: string, options: any) => string = null;
 let globExpander: (globs: string[]) => string[] = null;

--- a/tasks/modules/optionsResolver.js
+++ b/tasks/modules/optionsResolver.js
@@ -13,7 +13,7 @@ var propertiesFromTarget = ['amdloader', 'html', 'htmlOutDir', 'htmlOutDirFlatte
     'htmlOutputTemplate', 'htmlOutDirFlatten', 'htmlVarTemplate', 'inlineSourceMap', 'inlineSources', 'isolatedModules',
     'mapRoot', 'module', 'newLine', 'noEmit', 'noEmitHelpers', 'noEmitOnError', 'noImplicitAny', 'noResolve',
     'preserveConstEnums', 'removeComments', 'sourceRoot', 'sourceMap', 'suppressImplicitAnyIndexErrors', 'target',
-    'verbose', 'jsx', 'moduleResolution', 'experimentalAsyncFunctions', 'rootDir'], delayTemplateExpansion = ['htmlModuleTemplate', 'htmlVarTemplate'];
+    'verbose', 'jsx', 'moduleResolution', 'experimentalAsyncFunctions', 'rootDir'], delayTemplateExpansion = ['htmlModuleTemplate', 'htmlVarTemplate', 'htmlOutputTemplate'];
 var templateProcessor = null;
 var globExpander = null;
 function noopTemplateProcessor(templateString, options) {

--- a/tasks/modules/optionsResolver.ts
+++ b/tasks/modules/optionsResolver.ts
@@ -18,7 +18,7 @@ const propertiesFromTarget = ['amdloader', 'html', 'htmlOutDir', 'htmlOutDirFlat
         'mapRoot', 'module', 'newLine', 'noEmit', 'noEmitHelpers', 'noEmitOnError', 'noImplicitAny', 'noResolve',
         'preserveConstEnums', 'removeComments', 'sourceRoot', 'sourceMap', 'suppressImplicitAnyIndexErrors', 'target',
         'verbose', 'jsx', 'moduleResolution', 'experimentalAsyncFunctions', 'rootDir'],
-      delayTemplateExpansion = ['htmlModuleTemplate', 'htmlVarTemplate'];
+      delayTemplateExpansion = ['htmlModuleTemplate', 'htmlVarTemplate', 'htmlOutputTemplate'];
 
 let templateProcessor: (templateString: string, options: any) => string = null;
 let globExpander: (globs: string[]) => string[] = null;

--- a/test/expected/htmlExternal/html.external.html.ts
+++ b/test/expected/htmlExternal/html.external.html.ts
@@ -1,4 +1,3 @@
-/* tslint:disable:max-line-length */
 module html.external {
-  export var html = '<div>  This is an HTML file that we want to compile to a TypeScript external module.</div>';
+    export var html = '<div>  This is an HTML file that we want to compile to a TypeScript external module.</div>';
 }


### PR DESCRIPTION
After moving from 4.x to 5.1 I noticed that the html template stopped working. I pulled down the source and tracked down the issue. It looks like htmlOutputTemplate was missing from the delayTemplateExpansion array and grunt would replace the placeholders as it would try and resolve them (so your generated html.ts files would not have the html content). I looked to add a test but it looks like one was added but not being run correctly (it needed the html settings within the options object and the settings and expected template needed some tweaks to get the diff passing. As I was preparing this pull request I noticed someone else had also picked up on this issue as well.