### PR TITLE
fixing htmlOutputTemplate support for html2ts

### DIFF
--- a/tasks/modules/optionsResolver.js
+++ b/tasks/modules/optionsResolver.js
@@ -13,7 +13,7 @@ var propertiesFromTarget = ['amdloader', 'html', 'htmlOutDir', 'htmlOutDirFlatte
     'htmlOutputTemplate', 'htmlOutDirFlatten', 'htmlVarTemplate', 'inlineSourceMap', 'inlineSources', 'isolatedModules',
     'mapRoot', 'module', 'newLine', 'noEmit', 'noEmitHelpers', 'noEmitOnError', 'noImplicitAny', 'noResolve',
     'preserveConstEnums', 'removeComments', 'sourceRoot', 'sourceMap', 'suppressImplicitAnyIndexErrors', 'target',
-    'verbose', 'jsx', 'moduleResolution', 'experimentalAsyncFunctions', 'rootDir'], delayTemplateExpansion = ['htmlModuleTemplate', 'htmlVarTemplate'];
+    'verbose', 'jsx', 'moduleResolution', 'experimentalAsyncFunctions', 'rootDir'], delayTemplateExpansion = ['htmlModuleTemplate', 'htmlOutputTemplate', 'htmlVarTemplate'];
 var templateProcessor = null;
 var globExpander = null;
 function noopTemplateProcessor(templateString, options) {

--- a/tasks/modules/optionsResolver.ts
+++ b/tasks/modules/optionsResolver.ts
@@ -18,7 +18,7 @@ const propertiesFromTarget = ['amdloader', 'html', 'htmlOutDir', 'htmlOutDirFlat
         'mapRoot', 'module', 'newLine', 'noEmit', 'noEmitHelpers', 'noEmitOnError', 'noImplicitAny', 'noResolve',
         'preserveConstEnums', 'removeComments', 'sourceRoot', 'sourceMap', 'suppressImplicitAnyIndexErrors', 'target',
         'verbose', 'jsx', 'moduleResolution', 'experimentalAsyncFunctions', 'rootDir'],
-      delayTemplateExpansion = ['htmlModuleTemplate', 'htmlVarTemplate'];
+      delayTemplateExpansion = ['htmlModuleTemplate', 'htmlOutputTemplate', 'htmlVarTemplate'];
 
 let templateProcessor: (templateString: string, options: any) => string = null;
 let globExpander: (globs: string[]) => string[] = null;


### PR DESCRIPTION
htmlOutputTemplate cannot be interpolated before being passed to html2ts because it contains underscore/lodash template variables which need to be populated