### PR TITLE
newLine switch is removed on Windows platforms

### DIFF
--- a/tasks/modules/compile.ts
+++ b/tasks/modules/compile.ts
@@ -200,7 +200,7 @@ export function compileAllFiles(options: IGruntTSOptions, compilationInfo: IGrun
       if (options.inlineSourceMap) {
           args.push('--inlineSourceMap');
       }
-      if (options.newLine && !utils.newLineIsRedundant(options.newLine)) {
+      if (options.newLine) {
           args.push('--newLine', options.newLine);
       }
       if (options.isolatedModules) {


### PR DESCRIPTION
This optimization was buggy and remove the switch on any platform

I've tried to set newLine in tsconfig and as grunt-ts setting and the flag was removed always.

As workaround I've to enable passThrough (why is not set by default?)
```
        tsconfig: {
          passThrough: true
        }
```