### PR TITLE
Update README -> moduleResolution description -> default behavior

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Releases
 
 ## Next
+* DOCS: Update to `--moduleResolution` README section to show fluctuating default behaviour - by @thull
 
 ## v5.3.2 (2016-01-15)
 * FIX: Should not crash in presence of target named "src" (#321) - thanks for the report @ravishivt and @riggerthegeek.

--- a/README.md
+++ b/README.md
@@ -886,7 +886,7 @@ grunt.initConfig({
 #### moduleResolution
 
 ````javascript
-"node" (default) | "classic"
+"node" | "classic" (default)
 ````
 
 New in TypeScript 1.6.  TypeScript is gaining support for resolving definition files using rules similar to common JavaScript module loaders.  The first new one is support for CommonJS used by NodeJS, which is why this parameter is called `"node"`  The `"node"` setting performs an extra check to see if a definition file exists in the `node_modules/modulename` folder if a TypeScript definition can't be found for an imported module.  if this is not desired, set this setting to "classic".

--- a/README.md
+++ b/README.md
@@ -891,6 +891,8 @@ grunt.initConfig({
 
 New in TypeScript 1.6.  TypeScript is gaining support for resolving definition files using rules similar to common JavaScript module loaders.  The first new one is support for CommonJS used by NodeJS, which is why this parameter is called `"node"`  The `"node"` setting performs an extra check to see if a definition file exists in the `node_modules/modulename` folder if a TypeScript definition can't be found for an imported module.  if this is not desired, set this setting to "classic".
 
+On Defaults. When using `--module commonjs` the default `--moduleResolution` will be `node`. For all other `--module` options the default is `--moduleResolution classic`. If specified, the specified value will always be used.
+
 ````javascript
 grunt.initConfig({
   ts: {


### PR DESCRIPTION
As far as I can tell the default behavior of --moduleResolution is "classic". The docs should reflect this.