### PR TITLE
Add support for file names with multiple dashes on them.

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -419,6 +419,18 @@ module.exports = function (grunt) {
                     comments: true
                 },
             },
+            htmltestSnakeModuleName: {
+                test: true,
+                src: ['test/htmlSnakeModuleName/**/*.ts'],
+                html: ['test/htmlSnakeModuleName/**/*.tpl.html'],
+                reference: 'test/htmlSnakeModuleName/reference.ts',
+                out: 'test/htmlSnakeModuleName/out.js',
+                options: {
+                    htmlModuleTemplate: '<%= filename %>_<%= ext %>_module',
+                    htmlVarTemplate: '<%= filename %>_<%= ext %>_variable',
+                    comments: true
+                },
+            },
             htmlWithHtmlOutDirTest: {
                 test: true,
                 src: ['test/htmlOutDir/reference.ts','test/htmlOutDir/src/bar.ts',

--- a/tasks/modules/html2ts.js
+++ b/tasks/modules/html2ts.js
@@ -18,6 +18,12 @@ var escapeContent = function (content, quoteChar) {
     var nlReplace = '';
     return content.replace(quoteRegexp, '\\' + quoteChar).replace(/\r?\n/g, nlReplace);
 };
+// Convert a string to camelCase
+// Inspired by http://jamesroberts.name/blog/2010/02/22/string-functions-for-javascript-trim-to-camel-case-to-dashed-and-to-underscore/
+// Solves the issue of serving a module name that includes dashes
+var toCamel = function (str) {
+    return str.replace(/(\-[a-z])/g, function ($1) { return $1.toUpperCase().replace('-', ''); });
+};
 // Remove bom when reading utf8 files
 function stripBOM(str) {
     return 0xFEFF === str.charCodeAt(0)
@@ -40,8 +46,8 @@ function compileHTML(filename, options) {
     // TODO: place a minification pipeline here if you want.
     var ext = path.extname(filename).replace('.', '');
     var extFreename = path.basename(filename, '.' + ext);
-    var moduleName = options.moduleFunction({ ext: ext, filename: extFreename });
-    var varName = options.varFunction({ ext: ext, filename: extFreename }).replace(/\./g, '_');
+    var moduleName = toCamel(options.moduleFunction({ ext: ext, filename: extFreename }));
+    var varName = toCamel(options.varFunction({ ext: ext, filename: extFreename }).replace(/\./g, '_'));
     var fileContent;
     if (!options.htmlOutputTemplate) {
         fileContent = _.template(htmlInternalTemplate(options.eol))({ modulename: moduleName, varname: varName, content: htmlContent });

--- a/tasks/modules/html2ts.ts
+++ b/tasks/modules/html2ts.ts
@@ -22,6 +22,13 @@ var escapeContent = function (content: string, quoteChar= '\''): string {
     return content.replace(quoteRegexp, '\\' + quoteChar).replace(/\r?\n/g, nlReplace);
 };
 
+// Convert a string to camelCase
+// Inspired by http://jamesroberts.name/blog/2010/02/22/string-functions-for-javascript-trim-to-camel-case-to-dashed-and-to-underscore/
+// Solves the issue of serving a module name that includes dashes
+var toCamel = function(str){
+    return str.replace(/(\-[a-z])/g, function($1){return $1.toUpperCase().replace('-', ''); });
+};
+
 // Remove bom when reading utf8 files
 function stripBOM(str) {
     return 0xFEFF === str.charCodeAt(0)
@@ -60,8 +67,8 @@ export function compileHTML(filename: string, options: IHtml2TSOptions): string 
     var ext = path.extname(filename).replace('.', '');
     var extFreename = path.basename(filename, '.' + ext);
 
-    var moduleName = options.moduleFunction({ ext: ext, filename: extFreename });
-    var varName = options.varFunction({ ext: ext, filename: extFreename }).replace(/\./g, '_');
+    var moduleName = toCamel(options.moduleFunction({ ext: ext, filename: extFreename }));
+    var varName = toCamel(options.varFunction({ ext: ext, filename: extFreename }).replace(/\./g, '_'));
 
     var fileContent;
     if (!options.htmlOutputTemplate) {

--- a/test/expected/htmlSnakeModuleName/out.js
+++ b/test/expected/htmlSnakeModuleName/out.js
@@ -1,0 +1,15 @@
+/* tslint:disable:max-line-length */
+var snakeModuleName;
+(function (snakeModuleName) {
+    var tpl_html_module;
+    (function (tpl_html_module) {
+        tpl_html_module.snakeModuleName_tpl_html_variable = '<div> Some content </div>    <span> some other content </span> ';
+    })(tpl_html_module = snakeModuleName.tpl_html_module || (snakeModuleName.tpl_html_module = {}));
+})(snakeModuleName || (snakeModuleName = {}));
+/// <reference path="../reference.ts"/>
+var boo = snakeModuleName.tpl_html_module.snakeModuleName_tpl_html_variable;
+//grunt-start
+/// <reference path="src/snake-module-name.tpl.html.ts" />
+/// <reference path="src/foo.ts" />
+//grunt-end 
+//# sourceMappingURL=out.js.map

--- a/test/htmlSnakeModuleName/reference.ts
+++ b/test/htmlSnakeModuleName/reference.ts
@@ -1,0 +1,4 @@
+//grunt-start
+/// <reference path="src/snake-module-name.tpl.html.ts" />
+/// <reference path="src/foo.ts" />
+//grunt-end

--- a/test/htmlSnakeModuleName/src/foo.ts
+++ b/test/htmlSnakeModuleName/src/foo.ts
@@ -1,0 +1,3 @@
+/// <reference path="../reference.ts"/>
+
+var boo = snakeModuleName.tpl_html_module.snakeModuleName_tpl_html_variable;

--- a/test/htmlSnakeModuleName/src/snake-module-name.tpl.html
+++ b/test/htmlSnakeModuleName/src/snake-module-name.tpl.html
@@ -1,0 +1,2 @@
+<div> Some content </div>
+    <span> some other content </span> 

--- a/test/test.js
+++ b/test/test.js
@@ -65,6 +65,7 @@ exports.tests = {
     html2ts: function (test) {
         testDirectory(test, 'html');
         testDirectory(test, 'htmlTemplate');
+        testDirectory(test, 'htmlSnakeModuleName');
         test.done();
     },
     index: function (test) {

--- a/test/test.ts
+++ b/test/test.ts
@@ -80,6 +80,7 @@ export var tests : nodeunit.ITestGroup = {
     html2ts: function (test) {
         testDirectory(test, 'html');
         testDirectory(test, 'htmlTemplate');
+        testDirectory(test, 'htmlSnakeModuleName');
         test.done();
     },
     index: function (test) {


### PR DESCRIPTION
When compiling html files with names containing dashes, the compile function creates invalid ts output.

I've started using dashes in my file names as suggested by [JohnPapa's style guide](https://github.com/johnpapa/angular-styleguide#style-y121).  This pull request is inspired by https://github.com/TypeStrong/grunt-ts/pull/237

Options used:
```
options: {
    htmlModuleTemplate: '<%= filename %>_<%= ext %>_module',    // Template for module name for generated ts from html files [(default) '<%= filename %>']
    htmlVarTemplate:    '<%= filename %>_<%= ext %>_variable',  // Template for variable name used in generated ts from html files [(default) '<%= ext %>]
},
```

Example:
`example-page.tpl.html` -> `example-page.tpl.html.ts`

Outputs
```
/* tslint:disable:max-line-length */
module example-page.tpl_html_module {
    export var example-page.tpl_html_variable = '<div>Hello World</div>';
}
```

With compile errors:
```
example-page.tpl.html.ts(2,15): error TS1005: '{' expected.
example-page.tpl.html.ts(2,37): error TS1005: ';' expected.
example-page.tpl.html.ts(3,21): error TS1005: '=' expected.
example-page.tpl.html.ts(3,45): error TS1005: ',' expected.
example-page.tpl.html.ts(3,47): error TS1134: Variable declaration expected.
```

Dashes are not accepted as variable (and module) names, so I added a fix that would convert a dash to camelCase. I've also added the relevant tests. I hope my contribution is correct and useful!