### PR TITLE
Fast compilation should work if there are type errors and failOnTypeErrors is false

### DIFF
--- a/tasks/modules/compile.js
+++ b/tasks/modules/compile.js
@@ -313,7 +313,7 @@ function compileAllFiles(options, compilationInfo) {
     }
     // Execute command
     return executeNode(command, options).then(function (result) {
-        if (options.fast !== 'never' && result.code === 0) {
+        if (options.fast !== 'never' && (result.code === 0 || !options.failOnTypeErrors && result.code === 2)) {
             resetChangedFiles(newFiles, options.targetName);
         }
         result.fileCount = files.length;

--- a/tasks/modules/compile.ts
+++ b/tasks/modules/compile.ts
@@ -355,7 +355,7 @@ export function compileAllFiles(options: IGruntTSOptions, compilationInfo: IGrun
     // Execute command
     return executeNode(command, options).then((result: ICompileResult) => {
 
-        if (options.fast !== 'never' && result.code === 0) {
+        if (options.fast !== 'never' && (result.code === 0 || !options.failOnTypeErrors && result.code === 2)) {
             resetChangedFiles(newFiles, options.targetName);
         }
 


### PR DESCRIPTION
Sorry for the lack of tests. :cry: 