### PR TITLE
Change typescript to peer dependency

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,4 +2,4 @@ language: node_js
 node_js:
   - "0.10"
 before_script:
-  - npm install -g grunt-cli
+  - npm install -g grunt-cli && npm install typescript@1.7.3

--- a/package.json
+++ b/package.json
@@ -45,12 +45,12 @@
     "ncp": "0.5.1",
     "rimraf": "2.2.6",
     "strip-bom": "^2.0.0",
-    "typescript": "1.7.3",
     "underscore": "1.5.1",
     "underscore.string": "2.3.3"
   },
   "peerDependencies": {
-    "grunt": "~0.4.0"
+    "grunt": "~0.4.0",
+    "typescript": "1.x"
   },
   "devDependencies": {
     "grunt": "~0.4.0",


### PR DESCRIPTION
I'm using `grunt-ts` library but I needed features from TypeScript 1.8.0, however `grunt-ts` currently has a hardcoded dependency on TypeScript 1.7.3 even though version 1.7.5 is out since December and 1.8.0 was released on January 28th (https://libraries.io/npm/typescript/versions).

This situation is completely understandable because it's hard to demand from the maintainers of grunt-ts, to update this package as soon as new TypeScript version is released. Thus it'll always be a problem as long as TypeScript's package version is hardcoded. I think it's a much better idea to change it to `peerDependency` so that `grunt-ts` relies on user-installed TypeScript version. This way users can theoretically use any TypeScript version including legacy (for some reason) and nightly builds.

_Note: After this update some tests might fail if run with different TypeScript version installed locally. I'm not sure what's the approach here._