### PR TITLE
#361 update readme.md,  'module' property can be 'amd' or 'system' instead of 'commonjs'

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,7 +138,7 @@ For file ordering, look at [JavaScript Generation](#javascript-generation).
 |[jsx](#jsx)|option|`'preserve'`, `'react'`, (TypeScript default is `'react'`).  If `'preserve'`, TypeScript will emit `.jsx`; if `'react'`, TypeScript will transpile and emit `.js` files.|
 |[locale](#locale)|option|`string` - specify locale for error messages|
 |[mapRoot](#maproot)|option|`string` - root for referencing `.js.map` files in JS|
-|[module](#module)|option|default to be nothing, If you want to set it you set it to either `'amd'` or `'commonjs'`|
+|[module](#module)|option|default to be nothing, If you want to set it you set it to either `'amd'` or `'system'`|
 |[moduleResolution](#moduleresolution)|option|`'classic'` or `'node'`.  This was introduced in TypeScript 1.6.  The default is `'node'` if not passed.  [More details here](https://github.com/Microsoft/TypeScript/wiki/What%27s-new-in-TypeScript#adjustments-in-module-resolution-logic).|
 |[newLine](#newline)|option|`CRLF`, `LF`, `` (default) - If passed with a value, TypeScript will use the specified line endings.  Also affects grunt-ts transforms.|
 |[noEmit](#noemit)|option|`true`, `false` (default) - If passed as `true`, TypeScript will not emit even if it compiles cleanly|


### PR DESCRIPTION
Hi,
            This PR is to updating readme.md, since 'module' property can be 'amd' or 'system' instead of 'commonjs'.

Thank you for accepting it.

Cheers,
Yan