### PR TITLE
Adding support for Node 6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,8 @@
 language: node_js
 node_js:
+  - "6"
+  - "5"
+  - "4"
   - "0.10"
 before_script:
   - npm install -g grunt-cli

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "test": "grunt test"
   },
   "dependencies": {
-    "chokidar": "~1.0.0",
+    "chokidar": "~1.6.0",
     "csproj2ts": "0.0.7",
     "es6-promise": "~0.1.1",
     "lodash": "^4.13.0",


### PR DESCRIPTION
Hi!
     In the context of https://github.com/TypeStrong/grunt-ts/issues/369 I've created this mini PR with:
- Chokidar updated to latest version (1.6)
- Add node 4,5 and 6 to Travis build

I've run the tests in my local with node 6 and they work and I also tested with the original repo where the issue came up and it also works.

Thanks!
Fran