### PR TITLE
Fix: not to create `.baseDir.ts` file in case that `baseDir` is not specified and fast compile is not enabled

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -917,6 +917,26 @@ module.exports = function (grunt) {
                     noLib: true
                 }
             },
+            test_baseDirSpecified: {
+                test: true,
+                testExecute: commandLineAssertions.test_baseDirSpecified,
+                src: 'test/baseDirOption/baseDirSpecified/foo/bar.ts',
+                outDir: 'test/baseDirOption/outDir/baseDirSpecified/',
+                baseDir: 'test/baseDirOption/baseDirSpecified/',
+                options: {
+                    fast: 'never'
+                }
+            },
+            test_baseDirNotSpecified: {
+                test: true,
+                testExecute: commandLineAssertions.test_baseDirNotSpecified,
+                src: 'test/baseDirOption/baseDirNotSpecified/foo/bar.ts',
+                outDir: 'test/baseDirOption/outDir/baseDirNotSpecified/',
+                // `baseDir` is not specified
+                options: {
+                    fast: 'never'
+                }
+            },
             test_emitBOM: {
                 test: true,
                 testExecute: commandLineAssertions.test_emitBOM,

--- a/tasks/ts.js
+++ b/tasks/ts.js
@@ -84,11 +84,7 @@ function pluginFn(grunt) {
                 // see https://github.com/grunt-ts/grunt-ts/issues/77
                 function isBaseDirFile(filename, targetFiles) {
                     var baseDirFile = '.baseDir.ts';
-                    var bd = '';
-                    if (!options.baseDir) {
-                        bd = utils.findCommonPath(targetFiles, '/');
-                        options.baseDir = bd;
-                    }
+                    var bd = options.baseDir || utils.findCommonPath(targetFiles, '/');
                     return path.resolve(filename) === path.resolve(path.join(bd, baseDirFile));
                 }
                 // Create an amd loader?

--- a/tasks/ts.ts
+++ b/tasks/ts.ts
@@ -112,11 +112,7 @@ function pluginFn(grunt: IGrunt) {
                 function isBaseDirFile(filename: string, targetFiles: string[]) {
 
                     var baseDirFile: string = '.baseDir.ts';
-                    var bd = '';
-                    if (!options.baseDir) {
-                        bd = utils.findCommonPath(targetFiles, '/');
-                        options.baseDir = bd;
-                    }
+                    var bd = options.baseDir || utils.findCommonPath(targetFiles, '/');
 
                     return path.resolve(filename) === path.resolve(path.join(bd, baseDirFile));
                 }

--- a/test/baseDirOption/baseDirNotSpecified/foo/bar.ts
+++ b/test/baseDirOption/baseDirNotSpecified/foo/bar.ts
@@ -1,0 +1,1 @@
+class Bar {}

--- a/test/baseDirOption/baseDirSpecified/foo/bar.ts
+++ b/test/baseDirOption/baseDirSpecified/foo/bar.ts
@@ -1,0 +1,1 @@
+class Bar {}

--- a/test/commandLineAssertions.js
+++ b/test/commandLineAssertions.js
@@ -581,4 +581,28 @@ function simpleCommandLineCheck(lookFor) {
     };
     return result;
 }
+var BASE_DIR_FILE_NAME = ".baseDir.ts";
+exports.test_baseDirSpecified = baseDirCheck(true);
+// Although a `.baseDir.ts` file should not be included in case that
+// the `baseDir` option is not specified (and the value of the `fast` option is 'never'),
+// a `.baseDir.ts` file is included actually.
+// This is a bug.
+exports.test_baseDirNotSpecified = baseDirCheck(true);
+function baseDirCheck(shouldBaseDirBeIncluded) {
+    return function (strings, options) {
+        return new Promise(function (resolve, reject) {
+            var command = strings[1].replace(/\\/g, '/');
+            var isBaseDirFileNameIncluded = (command.indexOf(BASE_DIR_FILE_NAME) !== -1);
+            if (isBaseDirFileNameIncluded === shouldBaseDirBeIncluded) {
+                resolve({
+                    code: 0,
+                    output: ""
+                });
+            }
+            else {
+                throw "expected " + (shouldBaseDirBeIncluded ? "" : "not ") + "to see " + BASE_DIR_FILE_NAME + " on the command line and didn't.  Got this: " + command;
+            }
+        });
+    };
+}
 //# sourceMappingURL=commandLineAssertions.js.map

--- a/test/commandLineAssertions.js
+++ b/test/commandLineAssertions.js
@@ -583,11 +583,7 @@ function simpleCommandLineCheck(lookFor) {
 }
 var BASE_DIR_FILE_NAME = ".baseDir.ts";
 exports.test_baseDirSpecified = baseDirCheck(true);
-// Although a `.baseDir.ts` file should not be included in case that
-// the `baseDir` option is not specified (and the value of the `fast` option is 'never'),
-// a `.baseDir.ts` file is included actually.
-// This is a bug.
-exports.test_baseDirNotSpecified = baseDirCheck(true);
+exports.test_baseDirNotSpecified = baseDirCheck(false);
 function baseDirCheck(shouldBaseDirBeIncluded) {
     return function (strings, options) {
         return new Promise(function (resolve, reject) {

--- a/test/commandLineAssertions.ts
+++ b/test/commandLineAssertions.ts
@@ -649,3 +649,29 @@ function simpleCommandLineCheck(lookFor: string) {
   };
   return result;
 }
+
+const BASE_DIR_FILE_NAME = ".baseDir.ts";
+export const test_baseDirSpecified = baseDirCheck(true);
+// Although a `.baseDir.ts` file should not be included in case that
+// the `baseDir` option is not specified (and the value of the `fast` option is 'never'),
+// a `.baseDir.ts` file is included actually.
+// This is a bug.
+export const test_baseDirNotSpecified = baseDirCheck(true);
+function baseDirCheck(shouldBaseDirBeIncluded: boolean): ICompilePromise {
+  return (strings, options) => {
+    return new Promise((resolve, reject) => {
+
+      const command = strings[1].replace(/\\/g,'/');
+
+      var isBaseDirFileNameIncluded = (command.indexOf(BASE_DIR_FILE_NAME) !== -1);
+      if (isBaseDirFileNameIncluded === shouldBaseDirBeIncluded) {
+        resolve({
+          code: 0,
+          output: ""
+        });
+      } else {
+        throw `expected ${shouldBaseDirBeIncluded ? "" : "not "}to see ${BASE_DIR_FILE_NAME} on the command line and didn't.  Got this: ${command}`;
+      }
+    });
+  };
+}

--- a/test/commandLineAssertions.ts
+++ b/test/commandLineAssertions.ts
@@ -652,11 +652,7 @@ function simpleCommandLineCheck(lookFor: string) {
 
 const BASE_DIR_FILE_NAME = ".baseDir.ts";
 export const test_baseDirSpecified = baseDirCheck(true);
-// Although a `.baseDir.ts` file should not be included in case that
-// the `baseDir` option is not specified (and the value of the `fast` option is 'never'),
-// a `.baseDir.ts` file is included actually.
-// This is a bug.
-export const test_baseDirNotSpecified = baseDirCheck(true);
+export const test_baseDirNotSpecified = baseDirCheck(false);
 function baseDirCheck(shouldBaseDirBeIncluded: boolean): ICompilePromise {
   return (strings, options) => {
     return new Promise((resolve, reject) => {


### PR DESCRIPTION
## Problem this pull request fixes

According to README of grunt-ts, when `--outDir` option is specified, `baseDir` is not specified and the value of `fast` option is "never", `.baseDir.ts` file should not be created. But in that case, `.baseDir.ts` file is created actually. I think this is a bug.
### Expected
- `.baseDir.ts` file is created when `baseDir` option is specified
- `.baseDir.ts` file is created when fast compile is enabled
- `.baseDir.ts` file is **NOT CREATED** when `baseDir` option is not specified and fast compile is not enabled
### Actual
- `.baseDir.ts` file is created when `baseDir` option is specified
- `.baseDir.ts` file is created when fast compile is enabled
- `.baseDir.ts` file is **CREATED** when `baseDir` option is not specified and fast compile is not enabled
## What I did
- Added tests for `baseDir` option : 19d2bab516b0a304efb8fb41ec91a2244304a16f
  - This tests shows the wrong behavior.
- Fixed the bug : 5319407d93ba45a0410591736603f334e266311e
## Relational issues
- Issues #300 
