### PR TITLE
Support tsconfig.json extends

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,7 +46,8 @@
     "ncp": "0.5.1",
     "rimraf": "2.2.6",
     "semver": "^5.3.0",
-    "strip-bom": "^2.0.0"
+    "strip-bom": "^2.0.0",
+    "jsmin2": "^1.2.1"
   },
   "peerDependencies": {
     "grunt": "^1.0.1 || ^0.4.0",

--- a/tasks/modules/interfaces.d.ts
+++ b/tasks/modules/interfaces.d.ts
@@ -211,6 +211,8 @@ interface ITSConfigFile {
     exclude?: string[];
     include?: string[];
     filesGlob?: string[];
+    /** this tsconfig overrides settings in its parent tsconfig located here */
+    extends?: string;
 }
 
 // NOTE: This is from tsconfig.ts in atom-typescript

--- a/tasks/modules/tsconfig.js
+++ b/tasks/modules/tsconfig.js
@@ -6,6 +6,7 @@ var path = require("path");
 var stripBom = require("strip-bom");
 var _ = require("lodash");
 var utils = require("./utils");
+var jsmin = require("jsmin2");
 var templateProcessor = null;
 var globExpander = null;
 var gruntfileGlobs = null;
@@ -86,7 +87,8 @@ function resolveAsync(applyTo, taskOptions, targetOptions, theTemplateProcessor,
                     projectSpec = {};
                 }
                 else {
-                    projectSpec = JSON.parse(content);
+                    var minifiedContent = jsmin(content);
+                    projectSpec = JSON.parse(minifiedContent.code);
                 }
             }
             catch (ex) {

--- a/tasks/modules/tsconfig.ts
+++ b/tasks/modules/tsconfig.ts
@@ -81,30 +81,42 @@ export function resolveAsync(applyTo: IGruntTSOptions,
         (<ITSConfigSupport>applyTo.tsconfig).tsconfig = '.';
       }
     } else {
-      let projectFile = (<ITSConfigSupport>applyTo.tsconfig).tsconfig;
-      try {
-        var projectFileTextContent = fs.readFileSync(projectFile, 'utf8');
-      } catch (ex) {
-        if (ex && ex.code === 'ENOENT') {
-            return reject('Could not find file "' + projectFile + '".');
-        } else if (ex && ex.errno) {
-            return reject('Error ' + ex.errno + ' reading "' + projectFile + '".');
-        } else {
-            return reject('Error reading "' + projectFile + '": ' + JSON.stringify(ex));
-        }
-      }
 
-      try {
-        var projectSpec: ITSConfigFile;
-        const content = stripBom(projectFileTextContent);
-        if (content.trim() === '') {
-          projectSpec = {};
-        } else {
-          const minifiedContent = jsmin(content);
-          projectSpec = JSON.parse(minifiedContent.code);
+      let projectSpec: ITSConfigFile = {extends: (<ITSConfigSupport>applyTo.tsconfig).tsconfig};
+      while (projectSpec.extends) {
+        const pathOfTsconfig = path.resolve(projectSpec.extends, '..');
+        try {
+          var projectFileTextContent = fs.readFileSync(projectSpec.extends, 'utf8');
+        } catch (ex) {
+          if (ex && ex.code === 'ENOENT') {
+              return reject('Could not find file "' + projectSpec.extends + '".');
+          } else if (ex && ex.errno) {
+              return reject('Error ' + ex.errno + ' reading "' + projectSpec.extends + '".');
+          } else {
+              return reject('Error reading "' + projectSpec.extends + '": ' + JSON.stringify(ex));
+          }
         }
-      } catch (ex) {
-        return reject('Error parsing "' + projectFile + '".  It may not be valid JSON in UTF-8.');
+        try {
+          const content = stripBom(projectFileTextContent);
+          if (content.trim() === '') {
+            // we are done.
+            projectSpec.extends = undefined;
+          } else {
+            const minifiedContent = jsmin(content);
+            const parentContent = JSON.parse(minifiedContent.code);
+            projectSpec = _.defaultsDeep(projectSpec, parentContent);
+            if (parentContent.extends) {
+              projectSpec.extends = path.resolve(pathOfTsconfig, parentContent.extends);
+              if (!_.endsWith(projectSpec.extends, '.json')) {
+                projectSpec.extends += '.json';
+              }
+            } else {
+              projectSpec.extends = undefined;
+            }
+          }
+        } catch (ex) {
+          return reject('Error parsing "' + projectSpec.extends + '".  It may not be valid JSON in UTF-8.');
+        }
       }
 
       applyTo = handleBadConfiguration(applyTo, projectSpec);

--- a/tasks/modules/tsconfig.ts
+++ b/tasks/modules/tsconfig.ts
@@ -7,6 +7,8 @@ import * as stripBom from 'strip-bom';
 import * as _ from 'lodash';
 import * as utils from './utils';
 import * as ts from '../ts';
+import * as jsmin from 'jsmin2';
+
 
 let templateProcessor: (templateString: string, options: any) => string = null;
 let globExpander: (globs: string[]) => string[] = null;
@@ -98,7 +100,8 @@ export function resolveAsync(applyTo: IGruntTSOptions,
         if (content.trim() === '') {
           projectSpec = {};
         } else {
-          projectSpec = JSON.parse(content);
+          const minifiedContent = jsmin(content);
+          projectSpec = JSON.parse(minifiedContent.code);
         }
       } catch (ex) {
         return reject('Error parsing "' + projectFile + '".  It may not be valid JSON in UTF-8.');

--- a/test/optionsResolverTests.js
+++ b/test/optionsResolverTests.js
@@ -907,6 +907,20 @@ exports.tests = {
                 test.strictEqual(result.warnings.length, 0, "expected zero warnings.");
                 test.done();
             }).catch(function (err) { test.ifError(err); test.done(); });
+        },
+        "tsconfig with extends and nostrictnull works as expected": function (test) {
+            test.expect(4);
+            var cfg = getConfig("minimalist");
+            cfg.tsconfig = {
+                tsconfig: './test/tsconfig_artifact/extends/tsconfig.nostrictnull.json',
+            };
+            var result = or.resolveAsync(null, cfg).then(function (result) {
+                test.strictEqual(result.strictNullChecks, false, "expected to get strict null checks disabled.");
+                test.strictEqual(result.noImplicitAny, true, "expected to get noImplicitAny from configs/base.json.");
+                test.ok(result.CompilationTasks[0].src.indexOf('test/abtest/a.ts') > -1, "expected to see a.ts included.");
+                test.ok(result.CompilationTasks[0].src.indexOf('test/abtest/b.ts') > -1, "expected to see b.ts included.");
+                test.done();
+            }).catch(function (err) { test.ifError(err); test.done(); });
         }
     }
 };

--- a/test/optionsResolverTests.ts
+++ b/test/optionsResolverTests.ts
@@ -971,6 +971,20 @@ export var tests : nodeunit.ITestGroup = {
       test.strictEqual(result.warnings.length, 0, "expected zero warnings.");
       test.done();
     }).catch((err) => {test.ifError(err); test.done();});
-  }
+  },
+    "tsconfig with extends and nostrictnull works as expected": function (test) {
+      test.expect(4);
+      var cfg = getConfig("minimalist");
+      cfg.tsconfig = {
+          tsconfig: './test/tsconfig_artifact/extends/tsconfig.nostrictnull.json',
+      };
+      var result = or.resolveAsync(null, cfg).then(function (result) {
+          test.strictEqual(result.strictNullChecks, false, "expected to get strict null checks disabled.");
+          test.strictEqual(result.noImplicitAny, true, "expected to get noImplicitAny from configs/base.json.");
+          test.ok(result.CompilationTasks[0].src.indexOf('test/abtest/a.ts') > -1, "expected to see a.ts included.");
+          test.ok(result.CompilationTasks[0].src.indexOf('test/abtest/b.ts') > -1, "expected to see b.ts included.");
+          test.done();
+      }).catch(function (err) { test.ifError(err); test.done(); });
+    }
   }
 };

--- a/test/tsconfig_artifact/extends/configs/base.json
+++ b/test/tsconfig_artifact/extends/configs/base.json
@@ -1,0 +1,6 @@
+{
+  "compilerOptions": {
+    "noImplicitAny": true,
+    "strictNullChecks": true
+  }
+}

--- a/test/tsconfig_artifact/extends/tsconfig.json
+++ b/test/tsconfig_artifact/extends/tsconfig.json
@@ -1,0 +1,7 @@
+{
+  "extends": "./configs/base",
+  "files": [
+    "../../abtest/a.ts",
+    "../../abtest/b.ts"
+  ]
+}

--- a/test/tsconfig_artifact/extends/tsconfig.nostrictnull.json
+++ b/test/tsconfig_artifact/extends/tsconfig.nostrictnull.json
@@ -1,0 +1,6 @@
+{
+  "extends": "./tsconfig",
+  "compilerOptions": {
+    "strictNullChecks": false
+  }
+}


### PR DESCRIPTION
Add support to grunt-ts for tsconfig.json `extends` feature.  Also supports comments in the tsconfig.json now (by minifying the file before calling JSON.parse()).