### PR TITLE
Cleanup npm package (#287)

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -17,6 +17,7 @@ npm-debug.log
 
 /tslint.json
 /tsd.json
+/tsconfig.json
 
 /.travis.yml
 /.jshintrc
@@ -26,8 +27,14 @@ npm-debug.log
 
 /tscommand*.tmp.txt
 
+/docs
+/AUTHORS
+/*.md
+/custom.TypeScript.targets
+
 /bin
 /obj
+/.vscode
 *.user
 *.suo
 *.csproj

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "url": "https://github.com/TypeStrong/grunt-ts/issues"
   },
   "license": "MIT",
-  "main": "grunt.js",
+  "main": "tasks/ts.js",
   "maintainers": [
     {
       "name": "nycdotnet",


### PR DESCRIPTION
Taking a swing at a fixing #287, this PR includes a couple of things:

 1. Adds a few extra resources to `.npmignore` so they aren't included in the package
 2. Points the `"main"` attribute in `package.json` to the right place