### PR TITLE
Support regex to prevent custom file from being cached

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,7 +169,7 @@ For file ordering, look at [JavaScript Generation](#javascript-generation).
 |[experimentalDecorators](#experimentaldecorators)|option|`true`, `false` (default) - set to true to enable support for proposed ECMAScript decorators|
 |[failOnTypeErrors](#failontypeerrors)|option|`true` (default), `false` - fail Grunt pipeline if there is a type error.  (See also [noEmitOnError](#noemithelpers))|
 |[fast](#fast)|option|`'watch'` (default), `'always'`, `'never'` - how to decide on a "fast" grunt-ts compile.|
-|[forceCompileRegex](#forceCompileRegex)|option| - Prevents files from being cached matching the given regex.|
+|[forceCompileRegex](#forceCompileRegex)|option|Prevents files matching the given regex from being cached.|
 |[files](#files)|target|Sets of files to compile and optional output destination|
 |[forceConsistentCasingInFileNames](#forceconsistentcasinginfilenames)|option|`true`, `false` (default) - Disallow inconsistently-cased references to the same file.|
 |[html](#html)|target|`string` or `string[]` - glob to HTML templates|

--- a/README.md
+++ b/README.md
@@ -169,6 +169,7 @@ For file ordering, look at [JavaScript Generation](#javascript-generation).
 |[experimentalDecorators](#experimentaldecorators)|option|`true`, `false` (default) - set to true to enable support for proposed ECMAScript decorators|
 |[failOnTypeErrors](#failontypeerrors)|option|`true` (default), `false` - fail Grunt pipeline if there is a type error.  (See also [noEmitOnError](#noemithelpers))|
 |[fast](#fast)|option|`'watch'` (default), `'always'`, `'never'` - how to decide on a "fast" grunt-ts compile.|
+|[forceCompileRegex](#forceCompileRegex)|option| - Prevents files from being cached matching the given regex.|
 |[files](#files)|target|Sets of files to compile and optional output destination|
 |[forceConsistentCasingInFileNames](#forceconsistentcasinginfilenames)|option|`true`, `false` (default) - Disallow inconsistently-cased references to the same file.|
 |[html](#html)|target|`string` or `string[]` - glob to HTML templates|

--- a/tasks/modules/compile.ts
+++ b/tasks/modules/compile.ts
@@ -115,6 +115,20 @@ export function compileAllFiles(options: Partial<IGruntTSOptions>, compilationIn
             newFiles = getChangedFiles(files, options.targetName, options.tsCacheDir, options.verbose);
 
             if (newFiles.length !== 0 || options.testExecute || utils.shouldPassThrough(options)) {
+                if (options.forceCompileRegex) {
+                    const regex = new RegExp(options.forceCompileRegex);
+                    
+                    // Finds all force compile files
+                    const additionalFiles = files.filter((file) => {
+                        return regex.test(file);
+                    });
+                    
+                    // Adds them to newFiles and unique the array
+                    newFiles = newFiles.concat(additionalFiles).filter((value, index, self) => {
+                        return self.indexOf(value) === index;
+                    });
+                }
+                
                 files = newFiles;
 
                 // If outDir is specified but no baseDir is specified we need to determine one

--- a/tasks/modules/defaults.ts
+++ b/tasks/modules/defaults.ts
@@ -33,6 +33,7 @@ const TypeScriptDefaults: IGruntTSOptions = {
     experimentalDecorators: false,
     failOnTypeErrors: null,
     fast: null,
+    forceCompileRegex: null,
     forceConsistentCasingInFileNames: false,
     html: null,
     htmlModuleTemplate: null,

--- a/tasks/modules/interfaces.d.ts
+++ b/tasks/modules/interfaces.d.ts
@@ -77,6 +77,8 @@ interface ITaskOptions {
     failOnTypeErrors: boolean;
     /** grunt-ts specific setting - never | always | watch (default) */
     fast: string;
+    /** grunt-ts specific setting - never cached files regex */
+    forceCompileRegex: string;
     /** Disallow inconsistently-cased references to the same file. */
     forceConsistentCasingInFileNames: boolean;
     /** grunt-ts specific setting - template against which the HTML will be generated */

--- a/tasks/modules/optionsResolver.ts
+++ b/tasks/modules/optionsResolver.ts
@@ -41,6 +41,7 @@ const propertiesFromTarget = ['amdloader', 'baseDir', 'html', 'htmlOutDir', 'htm
         'experimentalDecorators',
         'failOnTypeErrors',  /* grunt-ts specific */
         'fast',  /* grunt-ts specific */
+        'forceCompileRegex',  /* grunt-ts specific */
         /* help purposefully not supported. */
         'forceConsistentCasingInFileNames',
         'htmlModuleTemplate',  /* grunt-ts specific */

--- a/test/expected/allowJs/result.js
+++ b/test/expected/allowJs/result.js
@@ -19,4 +19,3 @@ System.register("allowJsConsumer", ["allowJsLibrary"], function (exports_1, cont
     };
 });
 //# sourceMappingURL=result.js.map
-

--- a/test/expected/allowJs/result.js
+++ b/test/expected/allowJs/result.js
@@ -5,8 +5,8 @@ function writeIt(value) {
 exports.writeIt = writeIt;
 System.register("allowJsConsumer", ["allowJsLibrary"], function (exports_1, context_1) {
     "use strict";
-    var __moduleName = context_1 && context_1.id;
     var allowJsLibrary_1;
+    var __moduleName = context_1 && context_1.id;
     return {
         setters: [
             function (allowJsLibrary_1_1) {

--- a/test/expected/allowJs/result.js
+++ b/test/expected/allowJs/result.js
@@ -19,3 +19,4 @@ System.register("allowJsConsumer", ["allowJsLibrary"], function (exports_1, cont
     };
 });
 //# sourceMappingURL=result.js.map
+


### PR DESCRIPTION
When fast-compiling project with `.d.ts` files caching them meaning some typings will be missing,
this allows the user to control what get cached or not.