### PR TITLE
accept any grunt version 1.x as peer dependency (fix for issue 430)

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "strip-bom": "^2.0.0"
   },
   "peerDependencies": {
-    "grunt": "^1.0.3 || ^0.4.0",
+    "grunt": "^1.0.0 || ^0.4.0",
     "typescript": ">=1"
   },
   "devDependencies": {


### PR DESCRIPTION
fix for #430